### PR TITLE
feat: add Windows support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A free, self-hosted alternative to Cluely. Bring your own AI key (OpenAI · Anth
 ---
 
 > [!IMPORTANT]
-> **Please read this first.** cue tries to stay out of screen recordings/shares, but this is **best-effort, not guaranteed** — on macOS 15.4+ Apple can let modern capture tools see it anyway, and a phone camera always can. Using a hidden assistant during a **proctored exam, job interview, or recorded meeting** may break that platform's rules and, in some places, consent laws. cue is built for legitimate uses — your own notes, studying, accessibility, and practice. **You are responsible for how you use it.**
+> **Please read this first.** cue tries to stay out of screen recordings/shares, but this is **best-effort, not guaranteed** — on macOS 15.4+ Apple can let modern capture tools see it anyway, on Windows 10 builds older than 2004 it degrades to a black box instead of true exclusion, and a phone camera always can. Using a hidden assistant during a **proctored exam, job interview, or recorded meeting** may break that platform's rules and, in some places, consent laws. cue is built for legitimate uses — your own notes, studying, accessibility, and practice. **You are responsible for how you use it.**
 >
 > On Zoom specifically, whether cue is hidden depends on one setting — **Settings → Share Screen → Screen capture mode → "Advanced capture with window filtering."**
 >
@@ -37,11 +37,24 @@ cue floats a small glass panel on top of everything. It takes **three separate i
 
 It's a copilot for **live meetings** ("what do I say to that?") and **coding problems** (screenshot → full solution), and it's designed to be **invisible in screen shares** so it stays your private assistant.
 
+### Platform support
+
+|  | macOS | Windows 11 / 10 2004+ |
+|---|---|---|
+| Screen + coding help | ✅ | ✅ |
+| Your mic (the **You** channel) | ✅ | ✅ |
+| Meeting audio (the **Them** channel) | ❌ **unsupported** | ✅ |
+| Hidden from screen shares | ⚠️ best-effort, weaker on macOS 15.4+ | ✅ `WDA_EXCLUDEFROMCAPTURE` |
+| Permissions to grant | Microphone **and** Screen Recording | Microphone only |
+
+> [!NOTE]
+> **Meeting audio is Windows-only.** Chromium implements loopback (system) audio capture [only on Windows](https://www.electronjs.org/docs/latest/api/session#sessetdisplaymediarequesthandlerhandler-opts), so the features that depend on hearing the *other* person — **What should I say?**, **Follow-up questions**, and **Recap** — need Windows. On macOS cue still sees your screen and hears **you**, but the *Them* channel stays silent.
+
 ---
 
 ## Install
 
-There are two ways to install cue. **If you're not a developer, use Option A.**
+**On Windows, use Option B** — the prebuilt release is macOS-only for now. If you're not a developer and you're on a Mac, use Option A.
 
 ### Option A — Download the app (easiest)
 
@@ -58,9 +71,9 @@ There are two ways to install cue. **If you're not a developer, use Option A.**
 
 After that, cue opens normally forever.
 
-### Option B — Run from source (developers)
+### Option B — Run from source (macOS or Windows)
 
-You need [Node.js](https://nodejs.org) 18+ installed. No Xcode required.
+You need [Node.js](https://nodejs.org) 18+ installed. No Xcode and no Visual Studio build tools required — cue deliberately avoids native modules.
 
 ```bash
 git clone https://github.com/Blueturboguy07/cue.git
@@ -69,11 +82,15 @@ npm install
 npm start
 ```
 
-To build your own `cue.app`:
+That's the whole setup on Windows. There's no permission dance — grant the mic when Windows asks and you're done.
+
+To build a standalone app:
 ```bash
-npm run pack      # creates dist/mac-arm64/cue.app
+npm run pack        # unpacked app in dist/ (either OS)
+npm run dist:win    # Windows installer  -> dist/cue-win-x64.exe
+npm run dist        # macOS zip          -> dist/
 ```
-> Note: the packaged app is **ad-hoc signed** (no paid Apple certificate). macOS ties permission grants to the exact build, so **rebuilding resets the mic/screen permissions** — you'll grant them again. For everyday use, build once and keep it.
+> **macOS note:** the packaged app is **ad-hoc signed** (no paid Apple certificate). macOS ties permission grants to the exact build, so **rebuilding resets the mic/screen permissions** — you'll grant them again. For everyday use, build once and keep it. Windows has no equivalent problem.
 
 ---
 
@@ -81,12 +98,14 @@ npm run pack      # creates dist/mac-arm64/cue.app
 
 When cue opens the first time, a **built-in tutorial** walks you through everything below. You can reopen it anytime by clicking the **cue logo** (top-left of the pill). Here's the same thing in writing.
 
-### Step 1 — Grant two macOS permissions
+### Step 1 — Grant permissions
 
-cue can't help until macOS lets it see and hear. When you first use a feature, macOS will prompt you — click **Allow**. If a prompt doesn't appear, add cue manually:
+**On macOS — two grants.** cue can't help until macOS lets it see and hear. When you first use a feature, macOS will prompt you — click **Allow**. If a prompt doesn't appear, add cue manually:
 
 - **Microphone:** System Settings → **Privacy & Security** → **Microphone** → turn on **cue**.
 - **Screen Recording:** System Settings → **Privacy & Security** → **Screen Recording** → turn on **cue**. (This one grant covers both screenshots *and* meeting audio.) macOS may ask you to **quit & reopen** cue — let it.
+
+**On Windows — one grant.** Only the microphone needs permission. Settings → **Privacy & security** → **Microphone** → turn on **Microphone access** *and* **Let desktop apps access your microphone**. Screenshots and meeting audio need **no permission at all** on Windows — they work immediately.
 
 ### Step 2 — Add your AI key (bring your own)
 
@@ -114,6 +133,8 @@ cue is hidden from most screen-share tools automatically — **Google Meet, Micr
 
 ## How to use it
 
+> On Windows, press **`Ctrl`** wherever **`⌘`** appears below. cue's own UI relabels the keys to match your OS.
+
 - **`⌘` `↵` — Assist.** The do-the-smart-thing key. On a coding problem it solves it; in a conversation it tells you what to say. Works from anywhere.
 - **`⌘` `H` — Solve what's on screen.** Screenshots a coding problem and returns the approach, code, and time/space complexity.
 - **The `▢` button** (top bar) — start/stop **listening** to a meeting. The green dot means it's live.
@@ -132,11 +153,16 @@ cue is an [Electron](https://www.electronjs.org/) app. Everything runs locally e
 **The three inputs are kept completely separate:**
 - **Screen** — captured with Electron's `desktopCapturer` (full-resolution screenshots, taken only when a feature needs one).
 - **Your mic ("You")** — `getUserMedia` → downsampled to 16 kHz audio → transcribed.
-- **Meeting audio ("Them")** — `getDisplayMedia` loopback capture of your system's output audio, kept on its own channel so cue knows *who* said what.
+- **Meeting audio ("Them")** — `getDisplayMedia` loopback capture of your system's output audio, kept on its own channel so cue knows *who* said what. **Windows only** — Chromium doesn't implement loopback capture elsewhere, so on macOS this stream comes back video-only and the channel stays silent.
 
 Both audio streams are transcribed (OpenAI Whisper or Gemini) and fed, with an optional screenshot, to your AI model. Responses **stream** into the panel word-by-word.
 
-**The invisibility** is a single macOS window flag: `setContentProtection(true)`, which sets `NSWindowSharingNone`. This asks the window server to exclude cue from screen-capture streams. It's the same mechanism DRM apps and Zoom's own toolbar use. It is **not** a GPU trick or a special overlay layer — and on macOS 15.4+ Apple lets some capture tools ignore it, which is why it's best-effort (see the disclaimer at the top).
+**The invisibility** is a single window flag — `setContentProtection(true)` — which the OS enforces:
+
+- **macOS:** sets `NSWindowSharingNone`, asking the window server to exclude cue from capture streams. On macOS 15.4+ Apple lets some capture tools ignore it, which is why it's best-effort (see the disclaimer at the top).
+- **Windows:** sets `WDA_EXCLUDEFROMCAPTURE` via `SetWindowDisplayAffinity`, and the compositor drops the window from every capture path. Windows 10 builds before 2004 fall back to `WDA_MONITOR`, which renders a black box rather than truly excluding.
+
+It's the same mechanism DRM apps and Zoom's own toolbar use. It is **not** a GPU trick or a special overlay layer. Set `CUE_NO_PROTECT=1` to disable it while debugging.
 
 ```
 main process ──┬─ overlay window (frameless, transparent, always-on-top, content-protected)
@@ -150,14 +176,23 @@ renderer ──────┴─ the glass UI + mic capture + system-audio loop
 
 ## Troubleshooting
 
-**"It says give access, but I already gave access."**
+**"It says give access, but I already gave access." (macOS)**
 You probably granted an older build. Because the app is ad-hoc signed, a rebuild changes its identity and macOS stops honoring the old grant (the checkmark can linger). Toggle cue **off and on** in System Settings → Screen Recording, or remove and re-add it.
+
+**"What should I say?", "Follow-up questions", or "Recap" never hear the other person (macOS).**
+Expected — meeting audio is Windows-only (see [Platform support](#platform-support)). Your own mic still transcribes, so those features see the *You* side of the conversation but never the *Them* side.
+
+**cue has no dock or taskbar icon — how do I quit it?**
+That's deliberate; it stays out of your way. Press **`Ctrl` `Shift` `X`** (**`⌘` `⇧` `X`** on macOS). If the shortcut didn't register because another app claimed it, end the **cue** (or **electron**) process in Task Manager / Activity Monitor.
+
+**`npm start` crashes with `Cannot read properties of undefined (reading 'getPath')`.**
+Something in your environment set **`ELECTRON_RUN_AS_NODE=1`** — some editors and terminals do, notably VS Code's integrated terminal. That makes Electron boot as plain Node, so `require('electron')` returns a path string instead of the real module. Clear it and relaunch: `unset ELECTRON_RUN_AS_NODE` (PowerShell: `Remove-Item Env:\ELECTRON_RUN_AS_NODE`).
 
 **A feature returns "403" / "no access to model."**
 Your API key is restricted. Most often it's an OpenAI **project key that only allows chat models** — it works for screen/coding help but 403s on transcription (Whisper). Fix: enable audio/Whisper on the key, use an unrestricted key, or add a Gemini key (cue falls back to it for transcription).
 
 **Listening does nothing / no transcript.**
-Check Settings shows a transcription-capable key (OpenAI with Whisper, or Gemini). Also make sure Screen Recording is granted (meeting audio needs it).
+Check Settings shows a transcription-capable key (OpenAI with Whisper, or Gemini). On macOS, also make sure Screen Recording is granted (meeting audio needs it). On Windows, make sure **Let desktop apps access your microphone** is on — the top-level Microphone toggle alone isn't enough.
 
 **cue shows up in my Zoom share.**
 Set Zoom's **Screen capture mode** to *"Advanced capture with window filtering"* (see Step 3). And remember: on macOS 15.4+ this can still fail — it's best-effort.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cue",
   "version": "0.1.0",
-  "description": "Open-source macOS invisible AI overlay — three separate inputs (screen, mic, system audio) into an LLM. A Cluely-style copilot for meetings and coding problems.",
+  "description": "Open-source invisible AI overlay for macOS and Windows — three separate inputs (screen, mic, system audio) into an LLM. A Cluely-style copilot for meetings and coding problems.",
   "license": "GPL-3.0-or-later",
   "author": "cue",
   "main": "main.js",
@@ -39,7 +39,14 @@
     "win": {
       "target": [
         "nsis"
-      ]
+      ],
+      "artifactName": "${productName}-win-${arch}.${ext}"
+    },
+    "nsis": {
+      "oneClick": false,
+      "perMachine": false,
+      "allowToChangeInstallationDirectory": true,
+      "shortcutName": "cue"
     }
   },
   "keywords": [
@@ -48,7 +55,8 @@
     "ai",
     "assistant",
     "screencapturekit",
-    "macos"
+    "macos",
+    "windows"
   ],
   "devDependencies": {
     "electron": "33.2.1",

--- a/renderer/renderer.js
+++ b/renderer/renderer.js
@@ -5,6 +5,7 @@
   const $ = (s) => document.querySelector(s);
   const cmdKey = cue.platform === 'win32' ? 'Ctrl' : '⌘';
   const isCmdOrCtrl = (e) => cue.platform === 'win32' ? e.ctrlKey : e.metaKey;
+  const IS_MAC = cue.platform === 'darwin';   // used to branch onboarding copy per OS
 
   // ---- paint icons -------------------------------------------------------
   $('#logo-btn').innerHTML = icon('logo', { size: 18 });
@@ -185,7 +186,9 @@
       const stream = await navigator.mediaDevices.getDisplayMedia({ video: true, audio: true });
       stream.getVideoTracks().forEach((t) => t.stop()); // we only want the audio
       const tracks = stream.getAudioTracks();
-      if (!tracks.length) { cue.log('system audio: no loopback track (macOS loopback unsupported here)'); stream.getTracks().forEach((t) => t.stop()); return; }
+      // Chromium only implements loopback audio capture on Windows; elsewhere the
+      // stream comes back video-only and the "Them" channel stays silent.
+      if (!tracks.length) { cue.log('system audio: no loopback track (system-audio capture is Windows-only)'); stream.getTracks().forEach((t) => t.stop()); return; }
       sysStream = stream;
       sysCtx = new AudioContext({ sampleRate: 16000 });
       sysNode = sysCtx.createMediaStreamSource(new MediaStream(tracks));
@@ -331,13 +334,20 @@
       title: 'Welcome to cue',
       body: 'cue is a private AI copilot that floats over your screen. It can <strong>see your screen</strong>, <strong>hear your meetings</strong>, and help you answer questions or solve coding problems — while staying hidden from most screen shares.<br><br>This quick guide gets you running in about a minute.'
     },
-    {
+    IS_MAC ? {
       icon: '🔐',
       title: 'Allow cue to see & hear',
       body: 'cue needs two macOS permissions. Click each button, turn <strong>cue</strong> ON in the window that opens, then come back here.<ul><li><strong>Microphone</strong> — to hear you</li><li><strong>Screen Recording</strong> — to see your screen and hear meeting audio</li></ul>',
       buttons: [
         { label: 'Open Microphone settings', action: () => cue.openPane('x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone') },
         { label: 'Open Screen Recording settings', action: () => cue.openPane('x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture') }
+      ]
+    } : {
+      icon: '🔐',
+      title: 'Allow cue to hear you',
+      body: 'cue needs <strong>one</strong> Windows permission — the microphone. Click the button, then make sure both <strong>Microphone access</strong> and <strong>Let desktop apps access your microphone</strong> are <strong>On</strong>.<br><br>Seeing your screen and hearing meeting audio need <strong>no permission</strong> on Windows — they work right away.',
+      buttons: [
+        { label: 'Open Microphone settings', action: () => cue.openPane('ms-settings:privacy-microphone') }
       ]
     },
     {
@@ -349,7 +359,7 @@
     {
       icon: '🫥',
       title: 'Stay hidden in Zoom',
-      body: 'cue is hidden from most screen shares automatically (Google Meet, Teams, QuickTime — nothing to do). <strong>Zoom needs one setting:</strong><br><br>Zoom → <span class="hl">Settings</span> → <span class="hl">Share Screen</span> → <span class="hl">Advanced</span> → <strong>Screen capture mode</strong> → choose <strong>“Advanced capture with window filtering.”</strong><br><br>Avoid “<strong>without</strong> window filtering” — that mode reveals cue.'
+      body: 'cue is hidden from most screen shares automatically (Google Meet, Teams' + (IS_MAC ? ', QuickTime' : '') + ' — nothing to do). <strong>Zoom needs one setting:</strong><br><br>Zoom → <span class="hl">Settings</span> → <span class="hl">Share Screen</span> → <span class="hl">Advanced</span> → <strong>Screen capture mode</strong> → choose <strong>“Advanced capture with window filtering.”</strong><br><br>Avoid “<strong>without</strong> window filtering” — that mode reveals cue.'
     },
     {
       icon: '✨',

--- a/src/screen.js
+++ b/src/screen.js
@@ -1,5 +1,6 @@
 // Full-resolution screenshot via desktopCapturer (main process).
-// First call triggers the macOS Screen-Recording permission prompt for the app.
+// On macOS the first call triggers the Screen-Recording permission prompt;
+// Windows requires no permission for this.
 const { desktopCapturer, screen } = require('electron');
 
 async function captureScreenshot() {


### PR DESCRIPTION
## What this does

Makes cue's platform-specific pieces branch on `process.platform` instead of assuming macOS. The overlay, screenshot capture, and content protection already worked on Windows — what didn't were the keyboard accelerators, the onboarding permission step, and the build config.

- **`metaKey` → `ctrlKey` off macOS.** `metaKey` is the *Windows key* on Windows, so `Ctrl`+`Enter` (Assist) and `Ctrl`+`,` (Settings) were silently dead. `preload.js` now exposes `process.platform` and the renderer derives its accelerator from it.
- **Onboarding branches per platform.** Windows needs only the microphone grant — there's no Screen Recording gate at all — and its button opens `ms-settings:privacy-microphone`. The existing `x-apple.systempreferences:` URL is a no-op on Windows.
- **Keycaps** render `Ctrl`/`Enter`/`Shift` instead of `⌘`/`⏎`/`⇧`.
- **`package.json`** gains an `nsis` target and `npm run dist:win`.

No new dependencies. No changes to the prompt, LLM, or STT code.

## The part worth your attention: meeting audio is Windows-only

While porting I ran into something that isn't about Windows at all. Chromium implements loopback audio capture [only on Windows](https://www.electronjs.org/docs/latest/api/session#sessetdisplaymediarequesthandlerhandler-opts):

> Specifying a loopback device will capture system audio, and is currently only supported on Windows.

So the `audio: 'loopback'` in `setDisplayMediaRequestHandler` returns a video-only stream on macOS and the "Them" channel stays silent — meaning **What should I say?**, **Follow-up questions**, and **Recap** never receive the other person's audio on a Mac. The renderer already has a fallback branch for exactly this case (`no loopback track`), so I suspect this was already half-known.

The README currently reads as though this works everywhere, so I've added a platform-support table and a note. **If I've misread this, that part of the diff is easy to drop** — but it seems worth confirming before trusting the Them channel on macOS.

## How I verified it (Windows 11, build 26200)

- **Content protection holds.** `GetWindowDisplayAffinity` on the live overlay returns `0x00000011` (`WDA_EXCLUDEFROMCAPTURE`), and a desktop capture excludes the window entirely. With `CUE_NO_PROTECT=1` the affinity is `0x0` and the same capture shows the panel — so it's the flag doing the work, not an empty window.
- **Loopback audio works.** `getDisplayMedia` returns a real audio track (`system audio: capturing loopback`).
- **The Windows onboarding step renders**, and its `ms-settings:` link opens Settings at Privacy & security → Microphone.

## What I did *not* test

- **No macOS run.** I don't have a Mac. The `IS_MAC` branches are written to preserve existing macOS behavior exactly, but they are unverified on real hardware — worth a look before merging.
- **No provider round-trip.** I had no API key set, so I verified the chain up to the API call (audio → PCM → buffers → flush loop → "No transcription key set") but nothing past it.

## Notes

- One extra troubleshooting entry: running `npm start` from VS Code's integrated terminal crashes with `Cannot read properties of undefined (reading 'getPath')`, because that terminal exports `ELECTRON_RUN_AS_NODE=1` and Electron then boots as plain Node. Cost me a few minutes; documented it in case it catches anyone else.
- `setVisibleOnAllWorkspaces` is a documented no-op on Windows, so the panel doesn't follow across virtual desktops. Left as-is — it fails silently and harmlessly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
