### PR TITLE
feat: make Assist shortcut configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ cue floats a small glass panel on top of everything. It takes **three separate i
 
 | Feature | How to trigger | What it uses |
 |---|---|---|
-| **Assist** | `⌘` `↵` or the *Assist* button | your screen + recent conversation |
+| **Assist** | `⌘` `↵` by default (configurable) or the *Assist* button | your screen + recent conversation |
 | **What should I say?** | button | meeting audio + your mic |
 | **Follow-up questions** | button | the whole conversation |
 | **Recap** | button | the whole conversation |
@@ -114,7 +114,7 @@ cue is hidden from most screen-share tools automatically — **Google Meet, Micr
 
 ## How to use it
 
-- **`⌘` `↵` — Assist.** The do-the-smart-thing key. On a coding problem it solves it; in a conversation it tells you what to say. Works from anywhere.
+- **`⌘` `↵` — Assist.** The do-the-smart-thing key. On a coding problem it solves it; in a conversation it tells you what to say. Works from anywhere. Change this shortcut under **Settings → Keyboard shortcuts**.
 - **`⌘` `H` — Solve what's on screen.** Screenshots a coding problem and returns the approach, code, and time/space complexity.
 - **The `▢` button** (top bar) — start/stop **listening** to a meeting. The green dot means it's live.
 - **Type a question** in the box and press `↵` to ask about your screen or conversation.

--- a/main.js
+++ b/main.js
@@ -9,6 +9,13 @@ const { MODES } = require('./src/prompts');
 const { rms16 } = require('./src/wav');
 
 let win = null;
+let registeredAssistShortcut = null;
+
+const DEFAULT_ASSIST_SHORTCUT = 'CommandOrControl+Return';
+const RESERVED_SHORTCUTS = new Set([
+  'commandorcontrol+h',
+  'commandorcontrol+shift+x'
+]);
 
 // -------- capture / transcript state --------
 const state = { capturing: false, busy: false, transcribing: { you: false, them: false } };
@@ -188,6 +195,7 @@ async function runFeature(mode, userText) {
 // -------- IPC --------
 ipcMain.handle('settings:get', () => store.getSettings());
 ipcMain.handle('settings:set', (_e, patch) => { sttDisabled = false; return store.setSettings(patch); });
+ipcMain.handle('shortcut:assist:set', (_e, accelerator) => setAssistShortcut(accelerator));
 ipcMain.handle('capture:toggle', () => setCapturing(!state.capturing));
 ipcMain.handle('capture:state', () => ({ active: state.capturing }));
 ipcMain.on('ask', (_e, payload) => runFeature(payload.mode, payload.text));
@@ -198,10 +206,52 @@ ipcMain.on('open-pane', (_e, url) => { shell.openExternal(url).catch(() => {}); 
 ipcMain.on('log', (_e, msg) => console.log('[renderer]', msg));
 
 // -------- shortcuts --------
+function normalizeShortcut(accelerator) {
+  return typeof accelerator === 'string' ? accelerator.trim().replace(/\s+/g, '') : '';
+}
+
+function registerAssistShortcut(accelerator) {
+  const next = normalizeShortcut(accelerator) || DEFAULT_ASSIST_SHORTCUT;
+  if (next.length > 80) return { ok: false, error: 'That shortcut is too long.' };
+  if (RESERVED_SHORTCUTS.has(next.toLowerCase())) {
+    return { ok: false, error: 'That shortcut is reserved by another cue action.' };
+  }
+
+  const previous = registeredAssistShortcut;
+  if (previous) globalShortcut.unregister(previous);
+
+  try {
+    if (!globalShortcut.register(next, () => runFeature('assist', ''))) {
+      if (previous) globalShortcut.register(previous, () => runFeature('assist', ''));
+      return { ok: false, error: 'That shortcut is already in use by another application.' };
+    }
+  } catch (_) {
+    if (previous) globalShortcut.register(previous, () => runFeature('assist', ''));
+    return { ok: false, error: 'That key combination is not a valid global shortcut.' };
+  }
+
+  registeredAssistShortcut = next;
+  return { ok: true, accelerator: next };
+}
+
+function setAssistShortcut(accelerator) {
+  const result = registerAssistShortcut(accelerator);
+  if (result.ok) store.setSettings({ shortcuts: { assist: result.accelerator } });
+  return result;
+}
+
 function registerShortcuts() {
-  globalShortcut.register('CommandOrControl+Return', () => runFeature('assist', ''));
   globalShortcut.register('CommandOrControl+H', () => runFeature('leetcode', ''));
   globalShortcut.register('CommandOrControl+Shift+X', () => app.quit());
+
+  const settings = store.getSettings();
+  const configured = settings.shortcuts && settings.shortcuts.assist;
+  const result = registerAssistShortcut(configured || DEFAULT_ASSIST_SHORTCUT);
+  if (!result.ok && configured && configured !== DEFAULT_ASSIST_SHORTCUT) {
+    console.log('[cue] unable to register Assist shortcut:', result.error, 'Falling back to default.');
+    const fallback = registerAssistShortcut(DEFAULT_ASSIST_SHORTCUT);
+    if (fallback.ok) store.setSettings({ shortcuts: { assist: DEFAULT_ASSIST_SHORTCUT } });
+  }
 }
 
 // -------- lifecycle --------

--- a/preload.js
+++ b/preload.js
@@ -6,6 +6,7 @@ contextBridge.exposeInMainWorld('cue', {
   platform: process.platform,
   settingsGet: () => ipcRenderer.invoke('settings:get'),
   settingsSet: (patch) => ipcRenderer.invoke('settings:set', patch),
+  shortcutAssistSet: (accelerator) => ipcRenderer.invoke('shortcut:assist:set', accelerator),
   ask: (payload) => ipcRenderer.send('ask', payload),
   captureToggle: () => ipcRenderer.invoke('capture:toggle'),
   captureState: () => ipcRenderer.invoke('capture:state'),

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -77,6 +77,14 @@
         <div class="s-field"><span>Fast</span><input id="model-fast" type="text" autocomplete="off" /></div>
         <div class="s-field"><span>Smart</span><input id="model-smart" type="text" autocomplete="off" /></div>
 
+        <label class="s-label">Keyboard shortcuts</label>
+        <div class="s-shortcut">
+          <span>Assist</span>
+          <button id="shortcut-assist" class="shortcut-record" type="button" aria-label="Change Assist shortcut"></button>
+          <button id="shortcut-reset" class="shortcut-reset" type="button">Reset</button>
+        </div>
+        <div class="shortcut-hint" id="shortcut-hint">Click the shortcut, then press a new key combination.</div>
+
         <div class="s-status" id="s-status"></div>
       </div>
     </div>

--- a/renderer/renderer.js
+++ b/renderer/renderer.js
@@ -5,6 +5,7 @@
   const $ = (s) => document.querySelector(s);
   const cmdKey = cue.platform === 'darwin' ? '⌘' : 'Ctrl';
   const isCmdOrCtrl = (e) => cue.platform === 'darwin' ? e.metaKey : e.ctrlKey;
+  const DEFAULT_ASSIST_SHORTCUT = 'CommandOrControl+Return';
 
   // ---- paint icons -------------------------------------------------------
   $('#logo-btn').innerHTML = icon('logo', { size: 18 });
@@ -23,10 +24,36 @@
   let busy = false;
   let aiEl = null;       // current streaming <div class="ai-text">
   let caretEl = null;
+  let assistShortcut = DEFAULT_ASSIST_SHORTCUT;
+  let recordingShortcut = false;
 
   const messages = $('#messages');
 
   function esc(s) { return s.replace(/[&<>"]/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c])); }
+
+  function shortcutParts(accelerator) {
+    const labels = {
+      CommandOrControl: cue.platform === 'darwin' ? '⌘' : 'Ctrl',
+      Command: '⌘', Control: 'Ctrl', Super: 'Super',
+      Alt: cue.platform === 'darwin' ? '⌥' : 'Alt',
+      Shift: cue.platform === 'darwin' ? '⇧' : 'Shift',
+      Return: 'Enter', Escape: 'Esc', Space: 'Space',
+      Up: '↑', Down: '↓', Left: '←', Right: '→'
+    };
+    return (accelerator || DEFAULT_ASSIST_SHORTCUT).split('+').map((part) => labels[part] || part);
+  }
+
+  function shortcutKeycapsHtml(accelerator, className) {
+    const cls = className || 'keycap';
+    return shortcutParts(accelerator).map((part) => '<span class="' + cls + '">' + esc(part) + '</span>').join(' ');
+  }
+
+  function syncAssistShortcutLabels() {
+    const shortcutBtn = $('#shortcut-assist');
+    if (shortcutBtn && !recordingShortcut) shortcutBtn.textContent = shortcutParts(assistShortcut).join(' + ');
+    const placeholder = $('#placeholder');
+    if (placeholder) placeholder.innerHTML = 'Ask about your screen or conversation, or ' + shortcutKeycapsHtml(assistShortcut) + ' for Assist';
+  }
 
   // minimal, safe markdown: fenced code, bullets, inline code, bold, paragraphs
   function renderMarkdown(text) {
@@ -122,8 +149,11 @@
   }
   $('#send-btn').addEventListener('click', send);
   input.addEventListener('keydown', (e) => {
-    if (e.key === 'Enter' && !e.shiftKey && !isCmdOrCtrl(e)) { e.preventDefault(); send(); }
-    if (e.key === 'Enter' && isCmdOrCtrl(e)) { e.preventDefault(); runMode('assist', ''); }
+    const captured = keyEventToAccelerator(e);
+    if (captured.accelerator && captured.accelerator.toLowerCase() === assistShortcut.toLowerCase()) {
+      e.preventDefault(); runMode('assist', ''); return;
+    }
+    if (e.key === 'Enter' && !e.shiftKey && !e.metaKey && !e.ctrlKey && !e.altKey) { e.preventDefault(); send(); }
   });
 
   // Smart toggle
@@ -239,7 +269,7 @@
   // ---- settings ----------------------------------------------------------
   const scrim = $('#settings-scrim');
   function openSettings() { fillSettings(); scrim.classList.remove('hidden'); }
-  function closeSettings() { saveSettings(); scrim.classList.add('hidden'); }
+  function closeSettings() { cancelShortcutRecording(); saveSettings(); scrim.classList.add('hidden'); }
   $('#more-btn').addEventListener('click', openSettings);
   $('#s-close').addEventListener('click', closeSettings);
   scrim.addEventListener('click', (e) => { if (e.target === scrim) closeSettings(); });
@@ -252,6 +282,7 @@
     $('#key-nvidia').value = settings.apiKeys.nvidia || '';
     const m = settings.models[settings.provider] || { fast: '', smart: '' };
     $('#model-fast').value = m.fast; $('#model-smart').value = m.smart;
+    syncAssistShortcutLabels();
     $('#s-status').textContent = statusText();
   }
   function statusText() {
@@ -277,6 +308,104 @@
     settings.models[settings.provider].smart = $('#model-smart').value.trim();
     await cue.settingsSet(settings);
   }
+
+  // Assist shortcut recorder. The renderer captures a key combination and the
+  // main process only saves it after Electron confirms the global registration.
+  const shortcutBtn = $('#shortcut-assist');
+  const shortcutHint = $('#shortcut-hint');
+
+  function setShortcutHint(message, kind) {
+    shortcutHint.textContent = message;
+    shortcutHint.classList.toggle('error', kind === 'error');
+    shortcutHint.classList.toggle('success', kind === 'success');
+  }
+
+  function cancelShortcutRecording() {
+    recordingShortcut = false;
+    shortcutBtn.classList.remove('recording');
+    syncAssistShortcutLabels();
+  }
+
+  function keyEventToAccelerator(e) {
+    const modifierKeys = new Set(['Meta', 'Control', 'Alt', 'Shift']);
+    if (modifierKeys.has(e.key)) return { error: 'Press a modifier together with another key.' };
+
+    const parts = [];
+    const primaryDown = cue.platform === 'darwin' ? e.metaKey : e.ctrlKey;
+    if (primaryDown) parts.push('CommandOrControl');
+    if (cue.platform === 'darwin' && e.ctrlKey) parts.push('Control');
+    if (cue.platform !== 'darwin' && e.metaKey) parts.push('Super');
+    if (e.altKey) parts.push('Alt');
+    if (e.shiftKey) parts.push('Shift');
+
+    const named = {
+      Enter: 'Return', ' ': 'Space', Tab: 'Tab', Backspace: 'Backspace',
+      Delete: 'Delete', Insert: 'Insert', Home: 'Home', End: 'End',
+      PageUp: 'PageUp', PageDown: 'PageDown', ArrowUp: 'Up', ArrowDown: 'Down',
+      ArrowLeft: 'Left', ArrowRight: 'Right'
+    };
+    const punctuation = { '+': 'Plus', '-': '-', '=': '=', ',': ',', '.': '.', '/': '/', ';': ';', "'": "'", '[': '[', ']': ']', '\\': '\\', '`': '`' };
+    let key = named[e.key] || punctuation[e.key] || '';
+    if (!key && /^[a-z]$/i.test(e.key)) key = e.key.toUpperCase();
+    if (!key && /^[0-9]$/.test(e.key)) key = e.key;
+    if (!key && /^F(?:[1-9]|1[0-9]|2[0-4])$/.test(e.key)) key = e.key;
+    if (!key) return { error: 'Use a letter, number, function key, arrow, or common navigation key.' };
+    if (!parts.length && !/^F/.test(key)) return { error: 'Include Command/Ctrl, Alt, or Shift in the shortcut.' };
+    parts.push(key);
+    return { accelerator: parts.join('+') };
+  }
+
+  async function applyAssistShortcut(accelerator) {
+    const wasRecording = recordingShortcut;
+    recordingShortcut = false;
+    shortcutBtn.classList.remove('recording');
+    shortcutBtn.textContent = 'Saving…';
+    let result;
+    try {
+      result = await cue.shortcutAssistSet(accelerator);
+    } catch (_) {
+      result = { ok: false, error: 'cue could not update the shortcut. Please try again.' };
+    }
+    if (!result.ok) {
+      setShortcutHint(result.error, 'error');
+      recordingShortcut = wasRecording;
+      shortcutBtn.classList.toggle('recording', recordingShortcut);
+      if (recordingShortcut) shortcutBtn.textContent = 'Press keys…';
+      else syncAssistShortcutLabels();
+      return;
+    }
+    assistShortcut = result.accelerator;
+    if (!settings.shortcuts) settings.shortcuts = {};
+    settings.shortcuts.assist = assistShortcut;
+    cancelShortcutRecording();
+    setShortcutHint('Assist shortcut updated.', 'success');
+  }
+
+  shortcutBtn.addEventListener('click', () => {
+    recordingShortcut = true;
+    shortcutBtn.classList.add('recording');
+    shortcutBtn.textContent = 'Press keys…';
+    setShortcutHint('Press Escape to cancel.', '');
+  });
+
+  $('#shortcut-reset').addEventListener('click', () => applyAssistShortcut(DEFAULT_ASSIST_SHORTCUT));
+
+  document.addEventListener('keydown', (e) => {
+    if (!recordingShortcut) return;
+    e.preventDefault();
+    e.stopImmediatePropagation();
+    if (e.key === 'Escape') {
+      cancelShortcutRecording();
+      setShortcutHint('Shortcut change cancelled.', '');
+      return;
+    }
+    const captured = keyEventToAccelerator(e);
+    if (captured.error) {
+      setShortcutHint(captured.error, 'error');
+      return;
+    }
+    applyAssistShortcut(captured.accelerator);
+  }, true);
 
   // ---- example conversation (matches the reference screenshot) ------------
   function showExample() {
@@ -348,7 +477,7 @@
     {
       icon: '✨',
       title: 'You’re all set',
-      body: `How to use cue:<ul><li><span class="kbd">${cmdKey}</span> <span class="kbd">↵</span> — <strong>Assist</strong> with whatever's on screen or being said</li><li><span class="kbd">${cmdKey}</span> <span class="kbd">H</span> — solve a coding problem on screen</li><li>Click <strong>▢</strong> in the top bar to start listening to a meeting</li><li>Type a question and press <span class="kbd">↵</span></li></ul>Reopen this guide anytime by clicking the <strong>cue logo</strong>. Quit with <span class="kbd">${cmdKey}</span><span class="kbd">⇧</span><span class="kbd">X</span>.`
+      body: () => `How to use cue:<ul><li>${shortcutKeycapsHtml(assistShortcut, 'kbd')} — <strong>Assist</strong> with whatever's on screen or being said</li><li><span class="kbd">${cmdKey}</span> <span class="kbd">H</span> — solve a coding problem on screen</li><li>Click <strong>▢</strong> in the top bar to start listening to a meeting</li><li>Type a question and press <span class="kbd">↵</span></li></ul>Reopen this guide anytime by clicking the <strong>cue logo</strong>. Change Assist's shortcut in <strong>Settings</strong>. Quit with <span class="kbd">${cmdKey}</span><span class="kbd">⇧</span><span class="kbd">X</span>.`
     }
   ];
   let obIndex = 0;
@@ -356,7 +485,7 @@
     const step = OB_STEPS[obIndex];
     $('#ob-icon').textContent = step.icon;
     $('#ob-title').textContent = step.title;
-    $('#ob-body').innerHTML = step.body;
+    $('#ob-body').innerHTML = typeof step.body === 'function' ? step.body() : step.body;
     const btns = $('#ob-buttons'); btns.innerHTML = '';
     (step.buttons || []).forEach((b) => { const el = document.createElement('button'); el.textContent = b.label; el.addEventListener('click', b.action); btns.appendChild(el); });
     const dots = $('#ob-dots'); dots.innerHTML = '';
@@ -378,9 +507,8 @@
   // ---- boot --------------------------------------------------------------
   (async function boot() {
     settings = await cue.settingsGet();
-    if (cue.platform !== 'darwin') {
-      $('#placeholder').innerHTML = 'Ask about your screen or conversation, or <span class="keycap">Ctrl</span><span class="keycap">⏎</span> for Assist';
-    }
+    assistShortcut = (settings.shortcuts && settings.shortcuts.assist) || DEFAULT_ASSIST_SHORTCUT;
+    syncAssistShortcutLabels();
     smartBtn.classList.toggle('on', !!settings.smart);
     showExample();
     syncPlaceholder();
@@ -389,9 +517,5 @@
     $('#stop-btn').classList.toggle('active', st.active);
     if (!settings.onboarded) showOnboard();
 
-    if (cue.platform === 'win32') {
-      const keycaps = document.querySelectorAll('#placeholder .keycap');
-      if (keycaps.length > 0) keycaps[0].textContent = 'Ctrl';
-    }
   })();
 })();

--- a/renderer/styles.css
+++ b/renderer/styles.css
@@ -252,6 +252,27 @@ button:focus { outline: none; }
 .s-field span { width: 78px; color: var(--tx-mut); font-size: 12px; }
 .s-field input { flex: 1; padding: 8px 10px; border-radius: var(--r-8); border: 1px solid rgba(255,255,255,0.14); background: rgba(0,0,0,0.25); color: var(--tx-1); font-size: 13px; font-family: var(--font); outline: none; }
 .s-field input:focus { border-color: var(--accent); }
+.s-shortcut { display: flex; align-items: center; gap: 8px; }
+.s-shortcut > span { width: 78px; color: var(--tx-mut); font-size: 12px; }
+.shortcut-record, .shortcut-reset {
+  border-radius: var(--r-8); font-family: var(--font); cursor: pointer;
+  transition: all 140ms ease;
+}
+.shortcut-record {
+  flex: 1; min-height: 34px; padding: 7px 10px;
+  border: 1px solid rgba(255,255,255,0.14); background: rgba(0,0,0,0.25);
+  color: var(--tx-1); font-size: 12px; font-weight: 600;
+}
+.shortcut-record:hover { border-color: rgba(255,255,255,0.28); }
+.shortcut-record.recording { border-color: var(--accent); background: rgba(60,131,245,0.12); color: #cfe0ff; }
+.shortcut-reset {
+  padding: 7px 10px; border: 1px solid rgba(255,255,255,0.12);
+  background: rgba(255,255,255,0.04); color: var(--tx-mut); font-size: 12px;
+}
+.shortcut-reset:hover { background: rgba(255,255,255,0.08); color: var(--tx-2); }
+.shortcut-hint { min-height: 15px; margin-left: 88px; color: var(--tx-mut); font-size: 11px; line-height: 1.35; }
+.shortcut-hint.error { color: #ff9d8f; }
+.shortcut-hint.success { color: #78dba0; }
 .s-status { color: var(--tx-mut); font-size: 12px; margin-top: 10px; min-height: 16px; }
 
 /* ============================ Onboarding / tutorial ============================ */

--- a/src/store.js
+++ b/src/store.js
@@ -8,6 +8,7 @@ const FILE = path.join(app.getPath('userData'), 'cue-data.json');
 const DEFAULTS = {
   provider: 'openai',
   smart: false,
+  shortcuts: { assist: 'CommandOrControl+Return' },
   apiKeys: { openai: '', anthropic: '', gemini: '', deepgram: '', nvidia: '' },
   models: {
     openai: { fast: 'gpt-4o-mini', smart: 'gpt-4o' },


### PR DESCRIPTION
Closes #8

## What changed

- Added a keyboard-shortcut recorder under **Settings → Keyboard shortcuts** for the Assist action.
- Persisted the chosen Electron accelerator and registered it globally from the main process.
- Kept the previous shortcut active when a new combination is invalid, reserved, or already in use.
- Added reset, success, and error states, and updated the composer hint, onboarding guide, and README to reflect the active shortcut.

## Why

Assist was permanently bound to `CommandOrControl+Return`. Users could not avoid conflicts with other applications or choose a combination that better fits their workflow.

## Impact

The default remains unchanged, so existing users keep the current behavior. Users who customize it get the same shortcut everywhere in cue, including the global trigger, composer hint, and onboarding instructions.

## Root cause

The accelerator was hardcoded independently in the main-process global shortcut and renderer key handler, with no stored setting or registration feedback path.

## Validation

- Ran `node --check` across all project JavaScript files.
- Ran `git diff --check` successfully.
- Completed a clean dependency installation.
- Smoke-tested Electron startup.
- Built an unsigned Windows development package successfully.
