### PR TITLE
Add MiniMax provider with regional endpoint selection

### DIFF
--- a/renderer/index.html
+++ b/renderer/index.html
@@ -65,6 +65,7 @@
           <button data-provider="anthropic">Anthropic</button>
           <button data-provider="gemini">Gemini</button>
           <button data-provider="nvidia">Nvidia</button>
+          <button data-provider="minimax">MiniMax</button>
         </div>
 
         <label class="s-label">API keys <span class="s-hint">stored locally in cue-data.json</span></label>
@@ -72,6 +73,13 @@
         <div class="s-field"><span>Anthropic</span><input id="key-anthropic" type="password" placeholder="sk-ant-..." autocomplete="off" /></div>
         <div class="s-field"><span>Gemini</span><input id="key-gemini" type="password" placeholder="AIza..." autocomplete="off" /></div>
         <div class="s-field"><span>Nvidia</span><input id="key-nvidia" type="password" placeholder="nvapi-..." autocomplete="off" /></div>
+        <div class="s-field"><span>MiniMax</span><input id="key-minimax" type="password" placeholder="MiniMax API key" autocomplete="off" /></div>
+
+        <label class="s-label">MiniMax region <span class="s-hint">endpoint used for MiniMax requests</span></label>
+        <div class="s-seg" id="minimax-region-seg">
+          <button data-region="global_en">Global</button>
+          <button data-region="cn_zh">China</button>
+        </div>
 
         <label class="s-label" for="resume-context">Résumé / professional background <span class="s-hint">stored locally; sent to your selected provider with each request</span></label>
         <textarea id="resume-context" class="s-textarea" maxlength="12000" placeholder="Paste your résumé or professional background here. cue will use it as the factual source for career-related answers."></textarea>

--- a/renderer/renderer.js
+++ b/renderer/renderer.js
@@ -283,6 +283,8 @@
     $('#key-anthropic').value = settings.apiKeys.anthropic || '';
     $('#key-gemini').value = settings.apiKeys.gemini || '';
     $('#key-nvidia').value = settings.apiKeys.nvidia || '';
+    $('#key-minimax').value = settings.apiKeys.minimax || '';
+    document.querySelectorAll('#minimax-region-seg button').forEach((b) => b.classList.toggle('on', b.dataset.region === (settings.minimaxRegion || 'global_en')));
     $('#resume-context').value = settings.resumeContext || '';
     const m = settings.models[settings.provider] || { fast: '', smart: '' };
     $('#model-fast').value = m.fast; $('#model-smart').value = m.smart;
@@ -296,7 +298,7 @@
   });
   function statusText() {
     const k = settings.apiKeys;
-    const has = [k.openai && 'OpenAI', k.anthropic && 'Anthropic', k.gemini && 'Gemini', k.nvidia && 'Nvidia'].filter(Boolean);
+    const has = [k.openai && 'OpenAI', k.anthropic && 'Anthropic', k.gemini && 'Gemini', k.nvidia && 'Nvidia', k.minimax && 'MiniMax'].filter(Boolean);
     const stt = k.openai ? 'Whisper' : (k.gemini ? 'Gemini' : 'none');
     return 'Active: ' + settings.provider + ' · keys: ' + (has.join(', ') || 'none set') + ' · transcription: ' + stt;
   }
@@ -307,11 +309,16 @@
     $('#model-fast').value = m.fast; $('#model-smart').value = m.smart;
     $('#s-status').textContent = statusText();
   }));
+  document.querySelectorAll('#minimax-region-seg button').forEach((b) => b.addEventListener('click', () => {
+    settings.minimaxRegion = b.dataset.region;
+    document.querySelectorAll('#minimax-region-seg button').forEach((x) => x.classList.toggle('on', x === b));
+  }));
   async function saveSettings() {
     settings.apiKeys.openai = $('#key-openai').value.trim();
     settings.apiKeys.anthropic = $('#key-anthropic').value.trim();
     settings.apiKeys.gemini = $('#key-gemini').value.trim();
     settings.apiKeys.nvidia = $('#key-nvidia').value.trim();
+    settings.apiKeys.minimax = $('#key-minimax').value.trim();
     settings.resumeContext = $('#resume-context').value.trim();
     if (!settings.models[settings.provider]) settings.models[settings.provider] = {};
     settings.models[settings.provider].fast = $('#model-fast').value.trim();

--- a/src/llm.js
+++ b/src/llm.js
@@ -1,6 +1,13 @@
 const DEBUG = false; // Set to false to disable debug logging
-// LLM factory — OpenAI / Anthropic / Gemini behind one streaming interface.
+// LLM factory — OpenAI / Anthropic / Gemini / MiniMax behind one streaming interface.
 // stream({ system, turns:[{role,text}], imageDataUrl, maxTokens, onToken }) -> Promise<fullText>
+
+// MiniMax is OpenAI-compatible and exposes two regional gateways. MiniMax-M3
+// accepts image input, so it reuses the OpenAI screenshot path via baseURL.
+const MINIMAX_BASE_URLS = {
+  global_en: 'https://api.minimax.io/v1',
+  cn_zh: 'https://api.minimaxi.com/v1'
+};
 
 function stripDataUrl(dataUrl) {
   const m = /^data:(.+?);base64,(.*)$/s.exec(dataUrl || '');
@@ -110,7 +117,8 @@ function createLLM(settings) {
   const apiKey = keys[provider];
   const tier = settings.smart ? 'smart' : 'fast';
   const model = (settings.models[provider] || {})[tier];
-  
+  const minimaxRegion = settings.minimaxRegion || 'global_en';
+
   // Set to 4096 (effectively unlimited for a single response) 
   // since some SDKs like Anthropic require a maxTokens value.
   const maxTokens = 4096;
@@ -125,6 +133,7 @@ function createLLM(settings) {
       const args = { apiKey, model, maxTokens, ...params };
       if (provider === 'openai') return streamOpenAI(args);
       if (provider === 'nvidia') return streamOpenAI({ ...args, baseURL: 'https://integrate.api.nvidia.com/v1' });
+      if (provider === 'minimax') return streamOpenAI({ ...args, baseURL: MINIMAX_BASE_URLS[minimaxRegion] || MINIMAX_BASE_URLS.global_en });
       if (provider === 'anthropic') return streamAnthropic(args);
       if (provider === 'gemini') return streamGemini(args);
       throw new Error('unknown provider: ' + provider);

--- a/src/store.js
+++ b/src/store.js
@@ -10,12 +10,14 @@ const DEFAULTS = {
   smart: false,
   resumeContext: '',
   shortcuts: { assist: 'CommandOrControl+Return' },
-  apiKeys: { openai: '', anthropic: '', gemini: '', deepgram: '', nvidia: '' },
+  minimaxRegion: 'global_en',
+  apiKeys: { openai: '', anthropic: '', gemini: '', deepgram: '', nvidia: '', minimax: '' },
   models: {
     openai: { fast: 'gpt-4o-mini', smart: 'gpt-4o' },
     anthropic: { fast: 'claude-3-5-haiku-latest', smart: 'claude-3-5-sonnet-latest' },
     gemini: { fast: 'gemini-2.5-flash', smart: 'gemini-2.5-pro' },
-    nvidia: { fast: 'meta/llama-3.2-11b-vision-instruct', smart: 'meta/llama-3.2-90b-vision-instruct' }
+    nvidia: { fast: 'meta/llama-3.2-11b-vision-instruct', smart: 'meta/llama-3.2-90b-vision-instruct' },
+    minimax: { fast: 'MiniMax-M2.7', smart: 'MiniMax-M3' }
   }
 };
 
@@ -40,7 +42,7 @@ function load() {
   
   // Auto-switch provider if the current one has no key, but another one does.
   if (!data.apiKeys[data.provider]) {
-    const validProviders = ['openai', 'anthropic', 'gemini', 'nvidia'];
+    const validProviders = ['openai', 'anthropic', 'gemini', 'nvidia', 'minimax'];
     const active = validProviders.find(p => data.apiKeys[p]);
     if (active) {
       data.provider = active;

--- a/test/llm.test.js
+++ b/test/llm.test.js
@@ -1,0 +1,68 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const Module = require('node:module');
+
+// Stub the OpenAI SDK so we can observe how the MiniMax provider configures the
+// OpenAI-compatible client (base URL / key) without making any network calls.
+let capturedClientOptions = null;
+const originalLoad = Module._load;
+Module._load = function (request, parent, isMain) {
+  if (request === 'openai') {
+    return class FakeOpenAI {
+      constructor(opts) {
+        capturedClientOptions = opts;
+        this.chat = {
+          completions: {
+            create: async () => [{ choices: [{ delta: { content: 'ok' } }] }]
+          }
+        };
+      }
+    };
+  }
+  return originalLoad.apply(this, arguments);
+};
+
+const { createLLM } = require('../src/llm');
+
+test.after(() => { Module._load = originalLoad; });
+
+function minimaxSettings(overrides) {
+  return Object.assign({
+    provider: 'minimax',
+    smart: true,
+    apiKeys: { minimax: 'test-key' },
+    models: { minimax: { fast: 'MiniMax-M2.7', smart: 'MiniMax-M3' } }
+  }, overrides || {});
+}
+
+test('selects the MiniMax model for the active tier and reports readiness', () => {
+  const smart = createLLM(minimaxSettings({ smart: true }));
+  assert.equal(smart.provider, 'minimax');
+  assert.equal(smart.model, 'MiniMax-M3');
+  assert.equal(smart.ready, true);
+
+  const fast = createLLM(minimaxSettings({ smart: false }));
+  assert.equal(fast.model, 'MiniMax-M2.7');
+});
+
+test('routes MiniMax to the global OpenAI-compatible endpoint by default', async () => {
+  capturedClientOptions = null;
+  const llm = createLLM(minimaxSettings({ minimaxRegion: 'global_en' }));
+  await llm.stream({ system: 's', turns: [{ role: 'user', text: 'hi' }], onToken: () => {} });
+  assert.equal(capturedClientOptions.baseURL, 'https://api.minimax.io/v1');
+  assert.equal(capturedClientOptions.apiKey, 'test-key');
+});
+
+test('routes MiniMax to the China endpoint when that region is selected', async () => {
+  capturedClientOptions = null;
+  const llm = createLLM(minimaxSettings({ minimaxRegion: 'cn_zh' }));
+  await llm.stream({ system: 's', turns: [{ role: 'user', text: 'hi' }], onToken: () => {} });
+  assert.equal(capturedClientOptions.baseURL, 'https://api.minimaxi.com/v1');
+});
+
+test('falls back to the global endpoint for an unknown region', async () => {
+  capturedClientOptions = null;
+  const llm = createLLM(minimaxSettings({ minimaxRegion: 'unknown' }));
+  await llm.stream({ system: 's', turns: [{ role: 'user', text: 'hi' }], onToken: () => {} });
+  assert.equal(capturedClientOptions.baseURL, 'https://api.minimax.io/v1');
+});


### PR DESCRIPTION
Reason: The LLM factory supported several chat providers but had no MiniMax provider, key entry, model defaults, or regional endpoint selection, so MiniMax-M3 and MiniMax-M2.7 could not be used.

This adds MiniMax as a first-class provider behind the existing streaming interface.

## Changes
- `src/llm.js`: route the `minimax` provider through the existing OpenAI-compatible streaming path via `baseURL`. MiniMax-M3 accepts image input, so screenshots flow through the same OpenAI-compatible path already used for image messages. Global and China gateways are selected from `minimaxRegion`, defaulting to global and falling back to global for an unknown value.
- `src/store.js`: add the `minimax` API key, default models (`MiniMax-M3` for Smart, `MiniMax-M2.7` for Fast), the `minimaxRegion` default (`global_en`), and include `minimax` in the auto-switch provider list.
- `renderer/index.html`: add the MiniMax provider button, MiniMax API key field, and a Global/China region selector.
- `renderer/renderer.js`: load and persist the MiniMax key and region, wire the region selector, and include MiniMax in the settings status line.
- `test/llm.test.js`: cover MiniMax model/tier selection and region-to-endpoint routing (global default, China, and unknown-region fallback) with the OpenAI SDK stubbed so no network calls are made.

## Checks
- `node --test` — all 13 tests pass (9 existing + 4 new).
