### PR TITLE
Add OpenAI-compatible custom provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **An open-source AI copilot that floats over your screen — sees what you see, hears your meetings, and stays hidden from screen shares.**
 
-A free, self-hosted alternative to Cluely. Bring your own AI key (OpenAI · Anthropic · Google Gemini).
+A free, self-hosted alternative to Cluely. Bring your own AI key (OpenAI · Anthropic · Google Gemini · OpenAI-compatible endpoints).
 
 <img src="docs/tutorial.png" width="620" alt="cue first-run tutorial" />
 
@@ -86,6 +86,14 @@ cue uses **your own** API key, so it's free to run (you only pay your AI provide
 | **OpenAI** | [platform.openai.com/api-keys](https://platform.openai.com/api-keys) | One key does everything — **but** for the *listening* features the key must have **Whisper / audio** access (a "restricted" project key that only allows chat will give a 403 on transcription). |
 | **Anthropic (Claude)** | [console.anthropic.com](https://console.anthropic.com) | Great for screen & coding help. Claude has no speech-to-text, so add an OpenAI or Gemini key too if you want the listening features. |
 | **Google Gemini** | [aistudio.google.com/apikey](https://aistudio.google.com/apikey) | One key does chat + transcription. |
+| **Custom** | Your endpoint or gateway | Any OpenAI-compatible Chat Completions endpoint. The API key is optional for unauthenticated local servers. |
+
+To use an OpenAI-compatible endpoint, select **Custom** and configure its Base URL, API key, and Fast/Smart model IDs. Custom endpoints handle LLM requests only; listening continues to use Deepgram, OpenAI, or Gemini credentials.
+
+| Example | Base URL | Model |
+|---|---|---|
+| OpenClaw local gateway | `http://127.0.0.1:18789/v1` | `openclaw/default` |
+| Ollama | `http://127.0.0.1:11434/v1` | An installed Ollama model ID |
 
 Your key is stored **only on your computer** (in `cue-data.json`) and is sent **only** to that provider. cue has no server and collects nothing.
 
@@ -135,7 +143,7 @@ Both audio streams are transcribed (OpenAI Whisper or Gemini) and fed, with an o
 main process ──┬─ overlay window (frameless, transparent, always-on-top, content-protected)
                ├─ screenshot capture (desktopCapturer)
                ├─ speech-to-text (Whisper / Gemini)      ── "You" + "Them" channels
-               └─ LLM streaming (OpenAI / Anthropic / Gemini)
+               └─ LLM streaming (OpenAI / Anthropic / Gemini / Custom)
 renderer ──────┴─ the glass UI + mic capture + system-audio loopback
 ```
 
@@ -152,6 +160,9 @@ Your API key is restricted. Most often it's an OpenAI **project key that only al
 **Listening does nothing / no transcript.**
 Check Settings shows a transcription-capable key (OpenAI with Whisper, or Gemini). Also make sure Screen Recording is granted (meeting audio needs it).
 
+**A Custom provider request cannot connect.**
+Confirm the Base URL includes the endpoint's `/v1` path when required, the selected model ID exists on that endpoint, and the local gateway is running. Custom provider credentials are intentionally not reused for speech-to-text.
+
 **cue shows up in my Zoom share.**
 Set Zoom's **Screen capture mode** to *"Advanced capture with window filtering"* (see Step 3). And remember: on macOS 15.4+ this can still fail — it's best-effort.
 
@@ -164,6 +175,7 @@ Run `xattr -cr /Applications/cue.app` in Terminal once (see Install → Option A
 
 - No accounts, no servers, no telemetry. cue collects nothing.
 - Your API keys live in a local file (`cue-data.json`) and are sent only to the provider you chose.
+- When Custom is selected, its API key and LLM request data are sent to the Base URL you configured.
 - Your optional résumé text also lives in `cue-data.json` and is sent with each model request to your selected AI provider. It is stored as plain text; clear it in Settings to remove it.
 - Screenshots and audio are sent to your AI provider only when a feature runs, and are not stored by cue beyond the current session's transcript (kept in memory).
 

--- a/main.js
+++ b/main.js
@@ -331,7 +331,8 @@ async function runFeature(mode, userText) {
     send('llm:start', { userBubble, small: !!def.small, category });
 
     if (!llm.ready) {
-      send('llm:error', { message: 'Add your ' + settings.provider + ' API key in Settings (gear icon) to start. Model: ' + (llm.model || 'unset') + '.' });
+      const message = llm.configurationError || ('Complete the ' + settings.provider + ' provider settings. Model: ' + (llm.model || 'unset') + '.');
+      send('llm:error', { message });
       return;
     }
 

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -100,13 +100,21 @@
           <button data-provider="openai">OpenAI</button>
           <button data-provider="anthropic">Anthropic</button>
           <button data-provider="gemini">Gemini</button>
+          <button data-provider="custom">Custom</button>
         </div>
 
-        <label class="s-label">API keys <span class="s-hint">stored locally · never sent to any server</span></label>
+        <label class="s-label">API keys <span class="s-hint">stored locally in cue-data.json</span></label>
         <div class="s-field"><span>OpenAI</span><input id="key-openai" type="password" placeholder="sk-..." autocomplete="off" /></div>
         <div class="s-field"><span>Anthropic</span><input id="key-anthropic" type="password" placeholder="sk-ant-..." autocomplete="off" /></div>
         <div class="s-field"><span>Gemini</span><input id="key-gemini" type="password" placeholder="AIza..." autocomplete="off" /></div>
         <div class="s-field"><span>Deepgram</span><input id="key-deepgram" type="password" placeholder="dg-..." autocomplete="off" /></div>
+        <div class="s-field"><span>Custom</span><input id="key-custom" type="password" placeholder="optional" autocomplete="off" /></div>
+
+        <div id="custom-endpoint-settings" class="hidden">
+          <label class="s-label" for="base-url">Custom endpoint <span class="s-hint">OpenAI-compatible chat API</span></label>
+          <div class="s-field"><span>Base URL</span><input id="base-url" type="url" placeholder="http://127.0.0.1:18789/v1" autocomplete="off" spellcheck="false" /></div>
+          <div class="s-help">Your Custom key and LLM requests are sent to this URL. Speech-to-text continues to use Deepgram, OpenAI, or Gemini.</div>
+        </div>
 
         <label class="s-label">Models <span class="s-hint">fast = Smart off · smart = Smart on</span></label>
         <div class="s-field"><span>Fast</span><input id="model-fast" type="text" autocomplete="off" /></div>

--- a/renderer/renderer.js
+++ b/renderer/renderer.js
@@ -563,17 +563,18 @@
   // ---- settings ----------------------------------------------------------
   const scrim = $('#settings-scrim');
   function openSettings() { fillSettings(); scrim.classList.remove('hidden'); }
-  function closeSettings() { saveSettings(); scrim.classList.add('hidden'); }
+  async function closeSettings() {
+    if (await saveSettings()) scrim.classList.add('hidden');
+  }
   $('#more-btn').addEventListener('click', openSettings);
-  $('#s-close').addEventListener('click', closeSettings);
-  scrim.addEventListener('click', (e) => { if (e.target === scrim) closeSettings(); });
+  $('#s-close').addEventListener('click', () => { void closeSettings(); });
+  scrim.addEventListener('click', (e) => { if (e.target === scrim) void closeSettings(); });
 
   // Tab switching
   document.querySelectorAll('.s-tab').forEach((tab) => {
-    tab.addEventListener('click', () => {
-      if (!tab.classList.contains('on')) {
-        saveSettings().catch((err) => console.error('[cue] tab auto-save error', err));
-      }
+    tab.addEventListener('click', async () => {
+      if (tab.classList.contains('on')) return;
+      if (!(await saveSettings())) return;
       document.querySelectorAll('.s-tab').forEach(t => t.classList.remove('on'));
       document.querySelectorAll('.s-tab-pane').forEach(p => p.classList.add('hidden'));
       tab.classList.add('on');
@@ -582,6 +583,10 @@
     });
   });
 
+  function updateCustomProviderFields() {
+    $('#custom-endpoint-settings').classList.toggle('hidden', settings.provider !== 'custom');
+  }
+
   function fillSettings() {
     // Keys tab
     document.querySelectorAll('#provider-seg button').forEach((b) => b.classList.toggle('on', b.dataset.provider === settings.provider));
@@ -589,6 +594,9 @@
     $('#key-anthropic').value = settings.apiKeys.anthropic || '';
     $('#key-gemini').value = settings.apiKeys.gemini || '';
     $('#key-deepgram').value = settings.apiKeys.deepgram || '';
+    $('#key-custom').value = settings.apiKeys.custom || '';
+    $('#base-url').value = settings.baseUrl || '';
+    updateCustomProviderFields();
     const m = settings.models[settings.provider] || { fast: '', smart: '' };
     $('#model-fast').value = m.fast; $('#model-smart').value = m.smart;
     $('#s-status').textContent = statusText();
@@ -621,6 +629,7 @@
   document.querySelectorAll('#provider-seg button').forEach((b) => b.addEventListener('click', () => {
     settings.provider = b.dataset.provider;
     document.querySelectorAll('#provider-seg button').forEach((x) => x.classList.toggle('on', x === b));
+    updateCustomProviderFields();
     const m = settings.models[settings.provider] || { fast: '', smart: '' };
     $('#model-fast').value = m.fast; $('#model-smart').value = m.smart;
     $('#s-status').textContent = statusText();
@@ -633,6 +642,8 @@
     settings.apiKeys.anthropic = $('#key-anthropic').value.trim();
     settings.apiKeys.gemini = $('#key-gemini').value.trim();
     settings.apiKeys.deepgram = $('#key-deepgram').value.trim();
+    settings.apiKeys.custom = $('#key-custom').value.trim();
+    settings.baseUrl = $('#base-url').value.trim();
     if (!settings.models[settings.provider]) settings.models[settings.provider] = {};
     settings.models[settings.provider].fast = $('#model-fast').value.trim();
     settings.models[settings.provider].smart = $('#model-smart').value.trim();
@@ -647,9 +658,18 @@
     // Q&A
     settings.salaryTarget = $('#salary-target').value.trim();
     settings.questionsToAsk = $('#questions-to-ask').value.trim();
-    await cue.settingsSet(settings);
-    updatePrepStatus();
-    updateSmartTooltip();
+    try {
+      settings = await cue.settingsSet(settings);
+      $('#s-status').textContent = statusText();
+      updatePrepStatus();
+      updateSmartTooltip();
+      return true;
+    } catch (error) {
+      const message = error && error.message ? error.message : String(error);
+      $('#s-status').textContent = message;
+      $('#base-url').focus();
+      return false;
+    }
   }
 
   // ---- example conversation (matches the reference screenshot) ------------

--- a/renderer/styles.css
+++ b/renderer/styles.css
@@ -317,6 +317,7 @@ button:focus { outline: none; }
 .s-field span { width: 78px; color: var(--tx-mut); font-size: 12px; flex-shrink: 0; }
 .s-field input { flex: 1; padding: 8px 10px; border-radius: var(--r-8); border: 1px solid rgba(255,255,255,0.14); background: rgba(0,0,0,0.25); color: var(--tx-1); font-size: 13px; font-family: var(--font); outline: none; }
 .s-field input:focus { border-color: var(--accent); }
+.s-help { color: var(--tx-mut); font-size: 11px; line-height: 1.4; margin: 4px 0 2px 88px; }
 /* Textareas inside settings */
 #settings textarea {
   width: 100%; padding: 8px 10px; border-radius: var(--r-8);

--- a/src/llm.js
+++ b/src/llm.js
@@ -1,5 +1,14 @@
-// LLM factory — OpenAI / Anthropic / Gemini behind one streaming interface.
+// LLM factory — OpenAI, Anthropic, Gemini, and OpenAI-compatible APIs behind one streaming interface.
 // stream({ system, turns:[{role,text}], imageDataUrl, maxTokens, onToken }) -> Promise<fullText>
+
+const { createCompatibleClientOptions } = require('./openai-compatible');
+
+const CUSTOM_PROVIDER = 'custom';
+const DEFAULT_MODELS = {
+  openai: 'gpt-4o-mini',
+  anthropic: 'claude-3-5-haiku-latest',
+  gemini: 'gemini-2.0-flash'
+};
 
 function normalizeProviderName(provider) {
   if (!provider) return 'provider';
@@ -29,9 +38,9 @@ function stripDataUrl(dataUrl) {
   return m ? { mime: m[1], b64: m[2] } : null;
 }
 
-async function streamOpenAI({ apiKey, model, system, turns, imageDataUrl, maxTokens, onToken }) {
+async function streamOpenAI({ apiKey, baseURL, model, system, turns, imageDataUrl, maxTokens, onToken }) {
   const OpenAI = require('openai');
-  const client = new OpenAI({ apiKey });
+  const client = new OpenAI(baseURL ? { apiKey, baseURL } : { apiKey });
   const messages = [{ role: 'system', content: system }];
   turns.forEach((t, i) => {
     const last = i === turns.length - 1;
@@ -101,22 +110,45 @@ async function streamGemini({ apiKey, model, system, turns, imageDataUrl, maxTok
 function createLLM(settings) {
   const provider = settings.provider;
   const keys = settings.apiKeys || {};
-  const apiKey = keys[provider];
+  let apiKey = keys[provider];
+  let baseURL = '';
+  let configurationError = '';
   const tier = settings.smart ? 'smart' : 'fast';
-  let model = (settings.models[provider] || {})[tier];
+  const models = settings.models || {};
+  let model = (models[provider] || {})[tier];
   if (provider === 'gemini' && /^gemini-1\.5\-/.test(model || '')) {
     model = 'gemini-2.0-flash';
   }
-  if (!model) model = provider === 'gemini' ? 'gemini-2.0-flash' : (provider === 'openai' ? 'gpt-4o-mini' : 'claude-3-5-haiku-latest');
+  if (!model) model = DEFAULT_MODELS[provider] || '';
+
+  if (provider === CUSTOM_PROVIDER) {
+    try {
+      const clientOptions = createCompatibleClientOptions(apiKey, settings.baseUrl);
+      apiKey = clientOptions.apiKey;
+      baseURL = clientOptions.baseURL;
+    } catch (error) {
+      configurationError = error.message;
+    }
+    if (!model && !configurationError) {
+      configurationError = 'Set a Fast or Smart model for the Custom provider.';
+    }
+  } else if (!apiKey) {
+    configurationError = `Add your ${provider} API key in Settings.`;
+  }
+
+  const ready = !configurationError && !!model;
   const maxTokens = settings.smart ? 1400 : 700;
 
   return {
-    provider, model, apiKey,
-    ready: !!apiKey && !!model,
+    provider, model, apiKey, baseURL,
+    ready,
+    configurationError,
     async stream(params) {
-      const args = { apiKey, model, maxTokens, ...params, turns: sanitizeTurns(params.turns) };
+      if (!ready) throw new Error(configurationError || `Complete the ${provider} provider settings.`);
+      const args = { apiKey, baseURL, model, maxTokens, ...params, turns: sanitizeTurns(params.turns) };
       try {
         if (provider === 'openai') return await streamOpenAI(args);
+        if (provider === CUSTOM_PROVIDER) return await streamOpenAI(args);
         if (provider === 'anthropic') return await streamAnthropic(args);
         if (provider === 'gemini') return await streamGemini(args);
         throw new Error('unknown provider: ' + provider);

--- a/src/openai-compatible.js
+++ b/src/openai-compatible.js
@@ -1,0 +1,64 @@
+const SUPPORTED_BASE_URL_PROTOCOLS = new Set(['http:', 'https:']);
+const OPTIONAL_API_KEY_PLACEHOLDER = 'not-required';
+
+/**
+ * Normalize and validate an OpenAI-compatible API base URL.
+ *
+ * Credentials and query fragments are rejected because the configured API key
+ * is already sent through the Authorization header. Keeping secrets out of the
+ * URL also avoids accidental disclosure through logs and error messages.
+ *
+ * @param {unknown} value Raw setting value.
+ * @returns {string} A normalized URL without trailing slashes, or an empty string.
+ */
+function normalizeBaseUrl(value) {
+  const input = typeof value === 'string' ? value.trim() : '';
+  if (!input) return '';
+
+  let parsedUrl;
+  try {
+    parsedUrl = new URL(input);
+  } catch {
+    throw new Error('Base URL must be a valid HTTP or HTTPS URL.');
+  }
+
+  if (!SUPPORTED_BASE_URL_PROTOCOLS.has(parsedUrl.protocol)) {
+    throw new Error('Base URL must use HTTP or HTTPS.');
+  }
+  if (parsedUrl.username || parsedUrl.password) {
+    throw new Error('Base URL must not contain embedded credentials.');
+  }
+  if (parsedUrl.search || parsedUrl.hash) {
+    throw new Error('Base URL must not contain a query string or fragment.');
+  }
+
+  return parsedUrl.toString().replace(/\/+$/, '');
+}
+
+/**
+ * Build constructor options for the OpenAI SDK when targeting a compatible API.
+ * Local servers commonly require no API key, but the SDK requires a non-empty
+ * value, so a non-secret placeholder is supplied only when the setting is blank.
+ *
+ * @param {unknown} apiKey Raw API key setting.
+ * @param {unknown} baseUrl Raw base URL setting.
+ * @returns {{apiKey: string, baseURL: string}} OpenAI SDK client options.
+ */
+function createCompatibleClientOptions(apiKey, baseUrl) {
+  const baseURL = normalizeBaseUrl(baseUrl);
+  if (!baseURL) {
+    throw new Error('Set a Base URL for the Custom provider.');
+  }
+
+  const normalizedApiKey = typeof apiKey === 'string' ? apiKey.trim() : '';
+  return {
+    apiKey: normalizedApiKey || OPTIONAL_API_KEY_PLACEHOLDER,
+    baseURL
+  };
+}
+
+module.exports = {
+  OPTIONAL_API_KEY_PLACEHOLDER,
+  createCompatibleClientOptions,
+  normalizeBaseUrl
+};

--- a/src/store.js
+++ b/src/store.js
@@ -2,13 +2,15 @@
 const fs = require('fs');
 const path = require('path');
 const { app } = require('electron');
+const { normalizeBaseUrl } = require('./openai-compatible');
 
 const FILE = path.join(app.getPath('userData'), 'cue-data.json');
 
 const DEFAULTS = {
   provider: 'openai',
   smart: false,
-  apiKeys: { openai: '', anthropic: '', gemini: '', deepgram: '' },
+  baseUrl: '',
+  apiKeys: { openai: '', anthropic: '', gemini: '', deepgram: '', custom: '' },
   // Tab 2: Profile
   resumeText: '',
   jobDescription: '',
@@ -26,7 +28,8 @@ const DEFAULTS = {
   models: {
     openai: { fast: 'gpt-4o-mini', smart: 'gpt-4o' },
     anthropic: { fast: 'claude-3-5-haiku-latest', smart: 'claude-3-5-sonnet-latest' },
-    gemini: { fast: 'gemini-2.0-flash', smart: 'gemini-2.0-flash' }
+    gemini: { fast: 'gemini-2.0-flash', smart: 'gemini-2.0-flash' },
+    custom: { fast: '', smart: '' }
   }
 };
 
@@ -54,5 +57,12 @@ function save() { try { fs.writeFileSync(FILE, JSON.stringify(data, null, 2)); }
 
 module.exports = {
   getSettings() { return load(); },
-  setSettings(patch) { load(); data = deepMerge(data, patch || {}); save(); return data; }
+  setSettings(patch) {
+    load();
+    const nextSettings = deepMerge(data, patch || {});
+    nextSettings.baseUrl = normalizeBaseUrl(nextSettings.baseUrl);
+    data = nextSettings;
+    save();
+    return data;
+  }
 };

--- a/test/llm.test.js
+++ b/test/llm.test.js
@@ -1,0 +1,109 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const Module = require('node:module');
+const { OPTIONAL_API_KEY_PLACEHOLDER } = require('../src/openai-compatible');
+
+let capturedClientOptions = null;
+let capturedCompletionRequest = null;
+const originalModuleLoad = Module._load;
+
+Module._load = function loadWithOpenAIStub(request, parent, isMain) {
+  if (request === 'openai') {
+    return class FakeOpenAI {
+      constructor(clientOptions) {
+        capturedClientOptions = clientOptions;
+        this.chat = {
+          completions: {
+            create: async (completionRequest) => {
+              capturedCompletionRequest = completionRequest;
+              return [{ choices: [{ delta: { content: 'ok' } }] }];
+            }
+          }
+        };
+      }
+    };
+  }
+  return originalModuleLoad.call(this, request, parent, isMain);
+};
+
+const { createLLM } = require('../src/llm');
+
+test.after(() => {
+  Module._load = originalModuleLoad;
+});
+
+function createCustomSettings(overrides = {}) {
+  return {
+    provider: 'custom',
+    smart: false,
+    baseUrl: 'http://127.0.0.1:18789/v1',
+    apiKeys: { custom: 'gateway-token' },
+    models: { custom: { fast: 'openclaw/default', smart: 'openclaw/default' } },
+    ...overrides
+  };
+}
+
+test.beforeEach(() => {
+  capturedClientOptions = null;
+  capturedCompletionRequest = null;
+});
+
+test('routes the Custom provider through the configured OpenAI-compatible endpoint', async () => {
+  const receivedTokens = [];
+  const llm = createLLM(createCustomSettings());
+
+  assert.equal(llm.ready, true);
+  assert.equal(llm.model, 'openclaw/default');
+
+  const response = await llm.stream({
+    system: 'Be concise.',
+    turns: [{ role: 'user', text: 'Hello' }],
+    onToken: (token) => receivedTokens.push(token)
+  });
+
+  assert.deepEqual(capturedClientOptions, {
+    apiKey: 'gateway-token',
+    baseURL: 'http://127.0.0.1:18789/v1'
+  });
+  assert.equal(capturedCompletionRequest.model, 'openclaw/default');
+  assert.equal(response, 'ok');
+  assert.deepEqual(receivedTokens, ['ok']);
+});
+
+test('allows an unauthenticated local Custom endpoint', async () => {
+  const llm = createLLM(createCustomSettings({ apiKeys: { custom: '' } }));
+  await llm.stream({ system: '', turns: [], onToken: () => {} });
+
+  assert.equal(capturedClientOptions.apiKey, OPTIONAL_API_KEY_PLACEHOLDER);
+});
+
+test('does not apply the Custom Base URL to official OpenAI requests', async () => {
+  const llm = createLLM({
+    provider: 'openai',
+    smart: false,
+    baseUrl: 'http://127.0.0.1:18789/v1',
+    apiKeys: { openai: 'official-openai-key' },
+    models: { openai: { fast: 'gpt-4o-mini', smart: 'gpt-4o' } }
+  });
+
+  await llm.stream({ system: '', turns: [], onToken: () => {} });
+
+  assert.deepEqual(capturedClientOptions, { apiKey: 'official-openai-key' });
+});
+
+test('reports incomplete Custom endpoint settings without making a request', () => {
+  const llm = createLLM(createCustomSettings({ baseUrl: '' }));
+
+  assert.equal(llm.ready, false);
+  assert.match(llm.configurationError, /Set a Base URL/);
+  assert.equal(capturedClientOptions, null);
+});
+
+test('requires a model for the Custom provider', () => {
+  const llm = createLLM(createCustomSettings({
+    models: { custom: { fast: '', smart: '' } }
+  }));
+
+  assert.equal(llm.ready, false);
+  assert.match(llm.configurationError, /Set a Fast or Smart model/);
+});

--- a/test/openai-compatible.test.js
+++ b/test/openai-compatible.test.js
@@ -1,0 +1,41 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const {
+  OPTIONAL_API_KEY_PLACEHOLDER,
+  createCompatibleClientOptions,
+  normalizeBaseUrl
+} = require('../src/openai-compatible');
+
+test('normalizes whitespace and trailing slashes in a compatible base URL', () => {
+  assert.equal(
+    normalizeBaseUrl('  http://127.0.0.1:18789/v1///  '),
+    'http://127.0.0.1:18789/v1'
+  );
+  assert.equal(normalizeBaseUrl(''), '');
+});
+
+test('rejects unsafe or unsupported base URLs', () => {
+  assert.throws(() => normalizeBaseUrl('not a URL'), /valid HTTP or HTTPS URL/);
+  assert.throws(() => normalizeBaseUrl('ftp://localhost/v1'), /must use HTTP or HTTPS/);
+  assert.throws(() => normalizeBaseUrl('https://user:secret@example.com/v1'), /embedded credentials/);
+  assert.throws(() => normalizeBaseUrl('https://example.com/v1?token=secret'), /query string or fragment/);
+  assert.throws(() => normalizeBaseUrl('https://example.com/v1#section'), /query string or fragment/);
+});
+
+test('builds SDK options with an explicit API key', () => {
+  assert.deepEqual(
+    createCompatibleClientOptions(' gateway-token ', 'https://gateway.example/v1/'),
+    { apiKey: 'gateway-token', baseURL: 'https://gateway.example/v1' }
+  );
+});
+
+test('uses a non-secret placeholder when a local endpoint needs no API key', () => {
+  assert.deepEqual(
+    createCompatibleClientOptions('', 'http://127.0.0.1:11434/v1'),
+    { apiKey: OPTIONAL_API_KEY_PLACEHOLDER, baseURL: 'http://127.0.0.1:11434/v1' }
+  );
+});
+
+test('requires a base URL for an OpenAI-compatible client', () => {
+  assert.throws(() => createCompatibleClientOptions('', ''), /Set a Base URL/);
+});

--- a/test/stt.test.js
+++ b/test/stt.test.js
@@ -1,0 +1,16 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { createSTT } = require('../src/stt');
+
+test('keeps Custom chat credentials separate from speech-to-text providers', async () => {
+  const speechToText = createSTT({
+    apiKeys: {
+      custom: 'gateway-token'
+    }
+  });
+
+  assert.equal(speechToText.available, false);
+  assert.deepEqual(speechToText.providers, []);
+  assert.deepEqual(await speechToText.transcribe(Buffer.alloc(6400)), { text: '' });
+});


### PR DESCRIPTION
## Summary

- add a first-class **Custom** provider for OpenAI-compatible Chat Completions APIs
- persist and validate a configurable Base URL, with an optional API key for unauthenticated local endpoints
- keep Custom chat credentials isolated from official OpenAI requests and speech-to-text providers
- document OpenClaw and Ollama configuration examples

## User impact

Users can connect Cue to local gateways and compatible providers without changing the official OpenAI integration. Invalid or incomplete endpoint settings now produce actionable errors in Settings.

## Verification

- `npm test` (38 tests)
- JavaScript syntax checks with `node --check`
- `npm run pack` (Windows x64)
- live streaming smoke test through an OpenClaw gateway using `openclaw/default`

Closes #19
