### PR TITLE
Add persistent local whisper.cpp transcription

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,9 +36,42 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          for file in main.js preload.js renderer/*.js src/*.js test/*.js; do
+          for file in main.js preload.js electron-builder.cjs renderer/*.js src/*.js scripts/*.js test/*.js; do
             node --check "$file"
           done
 
       - name: Run tests
         run: npm test
+
+  runtime-smoke:
+    name: Local runtime (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, ubuntu-latest, macos-latest]
+
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v4
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Restore prepared runtime
+        uses: actions/cache@v4
+        with:
+          path: .cache/whisper-runtime
+          key: whisper-runtime-1.9.1-${{ runner.os }}-${{ runner.arch }}
+
+      - name: Prepare pinned runtime
+        run: npm run prepare:whisper
+
+      - name: Launch runtime smoke test
+        run: npm run verify:whisper-runtime

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest, windows-latest]
+        os: [macos-latest, windows-latest, ubuntu-latest]
 
     env:
       # A runner with no certificate can only produce an ad-hoc macOS build, and
@@ -30,11 +30,11 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
           cache: 'npm'
 
       - name: Install Dependencies
-        run: npm install
+        run: npm ci
 
       - name: Build macOS
         if: matrix.os == 'macos-latest'
@@ -56,6 +56,12 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Build Linux x64 and arm64
+        if: matrix.os == 'ubuntu-latest'
+        run: npm run dist:linux && npm run dist:linux:arm64
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Upload to GitHub Release
         # Skipped on macOS until signing is configured, so an ad-hoc build can
         # never replace a signed asset already attached to the release.
@@ -65,5 +71,6 @@ jobs:
           files: |
             dist/*.exe
             dist/*.zip
+            dist/*.AppImage
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules/
 # Build output
 dist/
 out/
+.cache/
 
 # Native binaries
 native/systemaudio

--- a/README.md
+++ b/README.md
@@ -60,7 +60,16 @@ To build a packaged app:
 ```bash
 npm run dist:mac    # macOS build
 npm run dist:win    # Windows build
+npm run dist:linux  # Linux x64 AppImage
 ```
+
+Packaged builds include a pinned `whisper.cpp` runtime. When running from source, prepare the matching runtime once:
+
+```bash
+npm run prepare:whisper
+```
+
+Windows x64 and Linux x64/arm64 use checksum-verified binaries from the pinned upstream release. macOS x64/arm64 builds `whisper-server` from the same pinned source tag and requires CMake plus Xcode command-line tools.
 
 > Note: permission grants can reset after a rebuild, so you may need to re-enable microphone/screen access after packaging a fresh build.
 
@@ -88,6 +97,17 @@ cue uses **your own** API key, so it's free to run (you only pay your AI provide
 | **Google Gemini** | [aistudio.google.com/apikey](https://aistudio.google.com/apikey) | One key does chat + transcription. |
 
 Your key is stored **only on your computer** (in `cue-data.json`) and is sent **only** to that provider. cue has no server and collects nothing.
+
+### Optional — transcribe locally with whisper.cpp
+
+Open **Settings → Audio**, choose **Local**, and download a model. `base.en` is the recommended English default; all 30 models supported by the official whisper.cpp download script are available, including multilingual, quantized, large, turbo, and TinyDiarize variants.
+
+Local mode is independent from the chat provider, so you can use local speech-to-text with OpenAI, Anthropic, or Gemini chat. The selected model loads once when listening starts, serves both the **You** and **Them** channels, and unloads only after queued speech has been transcribed when listening stops.
+
+- Audio inference stays on your computer and audio is never written to a temporary file.
+- Model files are downloaded only when you ask, support cancel/resume, and are checked against pinned byte counts and SHA-256 hashes.
+- Local mode never silently sends audio to a cloud fallback. A local failure is reported without sending the audio elsewhere.
+- Models are stored under Cue's Electron user-data directory and can be imported or deleted from Settings.
 
 ### Optional — tailor answers to your background
 
@@ -127,7 +147,9 @@ cue is an [Electron](https://www.electronjs.org/) app. Everything runs locally e
 - **Your mic ("You")** — `getUserMedia` → downsampled to 16 kHz audio → transcribed.
 - **Meeting audio ("Them")** — `getDisplayMedia` loopback capture of your system's output audio, kept on its own channel so cue knows *who* said what.
 
-Both audio streams are transcribed (OpenAI Whisper or Gemini) and fed, with an optional screenshot, to your AI model. Responses **stream** into the panel word-by-word.
+Both audio streams are transcribed by the independently selected speech provider (local whisper.cpp, Deepgram, OpenAI, or Gemini) and fed, with an optional screenshot, to your chat model. Responses **stream** into the panel word-by-word.
+
+When Local transcription is selected, Cue runs one persistent `whisper-server` sidecar bound to `127.0.0.1` on a temporary port with a random request path. Voice activity detection creates bounded in-memory utterances with pre-roll, and both channels share a serialized inference queue because one Whisper context must not process concurrent requests. Stop immediately ends new audio capture, drains the current queue for a bounded period, then terminates the sidecar.
 
 **The invisibility** is a single macOS window flag: `setContentProtection(true)`, which sets `NSWindowSharingNone`. This asks the window server to exclude cue from screen-capture streams. It's the same mechanism DRM apps and Zoom's own toolbar use. It is **not** a GPU trick or a special overlay layer — and on macOS 15.4+ Apple lets some capture tools ignore it, which is why it's best-effort (see the disclaimer at the top).
 
@@ -142,6 +164,15 @@ renderer ──────┴─ the glass UI + mic capture + system-audio loop
 ---
 
 ## Troubleshooting
+
+**Local transcription says the runtime is not prepared.**
+Packaged releases include the runtime. If you are running from source, run `npm run prepare:whisper` once and restart Cue. On macOS, install CMake and Xcode command-line tools first.
+
+**Local transcription says the model is missing or invalid.**
+Open **Settings → Audio**, select the model, and choose **Download**. A cancelled download can be resumed. If verification fails repeatedly, delete the partial/model file from the same screen and download it again.
+
+**A large local model is slow or runs out of memory.**
+Try `base.en`, `tiny.en`, or a quantized `q5`/`q8` model. Model size in Settings is the download size, not a guarantee of runtime RAM use; larger models require substantially more memory and CPU/GPU time.
 
 **"It says give access, but I already gave access."**
 You probably granted an older build. Because the app is ad-hoc signed, a rebuild changes its identity and macOS stops honoring the old grant (the checkmark can linger). Toggle cue **off and on** in System Settings → Screen Recording, or remove and re-add it.
@@ -162,10 +193,12 @@ Run `xattr -cr /Applications/cue.app` in Terminal once (see Install → Option A
 
 ## Privacy
 
-- No accounts, no servers, no telemetry. cue collects nothing.
+- No Cue accounts, hosted service, or telemetry. cue collects nothing.
 - Your API keys live in a local file (`cue-data.json`) and are sent only to the provider you chose.
 - Your optional résumé text also lives in `cue-data.json` and is sent with each model request to your selected AI provider. It is stored as plain text; clear it in Settings to remove it.
-- Screenshots and audio are sent to your AI provider only when a feature runs, and are not stored by cue beyond the current session's transcript (kept in memory).
+- In Local transcription mode, microphone and meeting audio stay on your computer. In cloud transcription modes, audio is sent only to the selected speech provider.
+- Audio utterances and the current transcript stay in memory; Cue does not write captured audio to disk. Downloaded local model files remain on disk until you delete them.
+- Screenshots are sent to your selected chat provider only when a feature needs the screen.
 
 ## Contributing
 
@@ -174,5 +207,7 @@ Issues and PRs welcome. cue is intentionally small and readable — `main.js` (a
 ## Credits & license
 
 Built as an open-source study of how tools like **Cluely** and **Interview Coder** work. Modeled on the open-source clones `pickle-com/glass` and `sohzm/cheating-daddy`.
+
+Local transcription uses [whisper.cpp](https://github.com/ggml-org/whisper.cpp), distributed under the MIT License. Its license notice is included in packaged runtimes.
 
 **License: [GPL-3.0-or-later](LICENSE).**

--- a/build-resources/whisper.cpp.LICENSE
+++ b/build-resources/whisper.cpp.LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023-2026 The ggml authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/electron-builder.cjs
+++ b/electron-builder.cjs
@@ -31,10 +31,12 @@ module.exports = {
   productName: "cue",
   asar: false,
   publish: null,
+  artifactName: "${productName}-${version}-${os}-${arch}.${ext}",
   files: ["main.js", "preload.js", "src/**/*", "renderer/**/*"],
   directories: { buildResources: "build-resources" },
+  afterPack: "scripts/after-pack.js",
   mac: {
-    target: [{ target: "zip", arch: ["arm64"] }],
+    target: [{ target: "zip", arch: ["x64", "arm64"] }],
     category: "public.app-category.productivity",
     // With a real cert, let electron-builder discover it and apply the hardened
     // runtime (notarization is refused without it). Without one, identity:null
@@ -58,5 +60,9 @@ module.exports = {
   },
   win: {
     target: [{ target: "nsis", arch: ["x64"] }],
+  },
+  linux: {
+    target: [{ target: "AppImage", arch: ["x64", "arm64"] }],
+    category: "Utility",
   },
 };

--- a/main.js
+++ b/main.js
@@ -1,4 +1,4 @@
-const { app, BrowserWindow, ipcMain, globalShortcut, screen, session, desktopCapturer, shell } = require('electron');
+const { app, BrowserWindow, ipcMain, globalShortcut, screen, session, desktopCapturer, shell, dialog } = require('electron');
 const path = require('path');
 const os = require('os');
 const store = require('./src/store');
@@ -10,6 +10,10 @@ const { rms16 } = require('./src/wav');
 const { createStreamingSTT } = require('./src/stt-streaming');
 const { AdaptiveVAD, AudioRingBuffer } = require('./src/vad');
 const { buildInterviewContext, detectCategory } = require('./src/interview-context');
+const { WhisperModelManager } = require('./src/whisper-model-manager');
+const { requireWhisperModel } = require('./src/whisper-model-catalog');
+const { locateWhisperRuntime } = require('./src/whisper-runtime');
+const { LocalWhisperTranscriber } = require('./src/local-whisper-transcriber');
 
 let win = null;
 const isMac = process.platform === 'darwin';
@@ -36,6 +40,11 @@ const FLUSH_MS = 900;
 const MIN_BYTES = Math.floor(16000 * 2 * 0.12); // ~0.12s
 const RMS_GATE = 180;
 let flushTimer = null;
+let whisperModelManager = null;
+let localWhisperTranscriber = null;
+let activeWhisperModelId = null;
+let desiredCaptureState = false;
+let captureTransition = Promise.resolve(false);
 
 // -------- streaming STT state --------
 let streamingSTT = { you: null, them: null }; // streaming STT instances per channel
@@ -68,6 +77,88 @@ function pushTranscript(turn) {
 }
 
 function send(channel, data) { if (win && !win.isDestroyed()) win.webContents.send(channel, data); }
+
+function getWhisperRuntime() {
+  return locateWhisperRuntime({
+    isPackaged: app.isPackaged,
+    resourcesPath: process.resourcesPath,
+    appPath: app.getAppPath(),
+    platform: process.platform,
+    architecture: process.arch,
+    environment: process.env
+  });
+}
+
+function publishTranscript(channel, text) {
+  if (!text || !text.trim()) return;
+  const turn = { channel, text: text.trim(), ts: Date.now() };
+  pushTranscript(turn);
+  send('transcript', turn);
+  send('stt:final', { channel, text: turn.text });
+}
+
+async function startLocalWhisper(settings) {
+  if (!whisperModelManager) throw new Error('The local Whisper model manager is not ready.');
+  const localSettings = settings.localWhisper || {};
+  const model = requireWhisperModel(localSettings.modelId || 'base.en');
+  const runtime = getWhisperRuntime();
+  if (!runtime.available) throw new Error(runtime.message);
+  activeWhisperModelId = model.id;
+  let transcriber = null;
+  try {
+    const modelPath = await whisperModelManager.verifyInstalledModel(model.id).catch((error) => {
+      if (error.code === 'ENOENT') {
+        throw new Error(`Download the ${model.id} model in Settings → Audio before listening.`);
+      }
+      throw error;
+    });
+
+    transcriber = new LocalWhisperTranscriber({
+      sessionOptions: {
+        executablePath: runtime.executablePath,
+        runtimeDirectory: runtime.runtimeDirectory,
+        modelPath,
+        language: model.englishOnly ? 'en' : (localSettings.language || 'auto'),
+        threads: Number(localSettings.threads) || 0,
+        tinydiarize: model.tinydiarize
+      },
+      onTranscript: publishTranscript,
+      onSpeechState: (channel, speaking, durationMs) => {
+        send('vad:state', { channel, speaking, durationMs });
+      },
+      onStatus: (status) => send('stt:status', { provider: 'local', ...status }),
+      onError: (error) => {
+        sttDisabled = true;
+        console.log('[local-whisper] error', error && error.message);
+        send('stt:status', { provider: 'local', status: 'error' });
+        send('status', { message: `Local transcription error: ${error.message}. Audio was not sent to a cloud fallback.` });
+      }
+    });
+
+    localWhisperTranscriber = transcriber;
+    await transcriber.start();
+  } catch (error) {
+    if (localWhisperTranscriber === transcriber) localWhisperTranscriber = null;
+    activeWhisperModelId = null;
+    if (transcriber) await transcriber.forceStop().catch(() => {});
+    throw error;
+  }
+}
+
+async function getWhisperOverview() {
+  if (!whisperModelManager) throw new Error('The local Whisper model manager is not ready.');
+  const runtime = getWhisperRuntime();
+  const models = await whisperModelManager.listModels();
+  return {
+    runtime: {
+      available: runtime.available,
+      version: runtime.version,
+      target: runtime.target,
+      message: runtime.message || null
+    },
+    models
+  };
+}
 
 // -------- window --------
 function createWindow() {
@@ -215,15 +306,7 @@ function stopFlushLoop() { if (flushTimer) { clearInterval(flushTimer); flushTim
 // -------- streaming STT setup --------
 function initStreamingSTT() {
   const settings = store.getSettings();
-  const keys = settings.apiKeys || {};
-
-  // Check if we have a streaming-capable key
-  if (!keys.deepgram && !keys.openai) {
-    streamingMode = false;
-    return false;
-  }
-
-  streamingMode = true;
+  streamingMode = false;
 
   ['you', 'them'].forEach((channel) => {
     const sttInstance = createStreamingSTT(settings, channel, {
@@ -238,13 +321,16 @@ function initStreamingSTT() {
       },
       onError: (err) => {
         console.log('[streaming-stt] error', err.provider, err.message);
-        // If streaming fails, disconnect cleanly then fall back to batch mode
+        const batchFallbackAvailable = createSTT(settings).available;
         stopStreamingSTT(); // close WebSockets and clear keep-alive intervals
-        if (!sttDisabled) {
+        if (batchFallbackAvailable) {
           send('status', { message: `Streaming transcription (${err.provider}) error: ${err.message}. Falling back to batch mode.` });
+          startFlushLoop();
+        } else if (!sttDisabled) {
+          sttDisabled = true;
+          send('status', { message: `Transcription stopped (${err.provider}): ${err.message}. The selected provider has no batch fallback.` });
         }
         streamingMode = false;
-        startFlushLoop(); // activate batch fallback
       },
       onStatusChange: (ch, status) => {
         send('stt:status', { channel: ch, status });
@@ -255,6 +341,7 @@ function initStreamingSTT() {
     });
 
     if (sttInstance.type === 'streaming' && sttInstance.instance) {
+      streamingMode = true;
       streamingSTT[channel] = sttInstance.instance;
       sttInstance.instance.connect();
     }
@@ -277,6 +364,11 @@ function stopStreamingSTT() {
 function routeAudio(channel, pcmBuffer) {
   const buf = Buffer.from(pcmBuffer);
 
+  if (localWhisperTranscriber) {
+    localWhisperTranscriber.push(channel, buf);
+    return;
+  }
+
   // Always run through VAD for speech state detection
   vad[channel].processChunk(buf);
 
@@ -296,25 +388,65 @@ function routeAudio(channel, pcmBuffer) {
 // Mic + system audio are both captured in the RENDERER (getUserMedia for the mic,
 // getDisplayMedia loopback for system audio) so they run inside cue's own process
 // and use cue's own Screen-Recording grant — no separate helper binary to authorize.
-function setCapturing(active) {
-  state.capturing = active;
+async function setCapturing(active) {
+  if (active === state.capturing) return state.capturing;
+
   if (active) {
     sttDisabled = false; // reset on re-enable
+    const settings = store.getSettings();
+    if ((settings.sttProvider || 'auto') === 'local') {
+      try {
+        await startLocalWhisper(settings);
+        state.capturing = true;
+        console.log('[cue] capture started, mode: local');
+        send('capture:state', { active: true, streaming: false, mode: 'local' });
+        return true;
+      } catch (error) {
+        state.capturing = false;
+        desiredCaptureState = false;
+        if (error.code === 'STARTUP_CANCELLED') {
+          send('stt:status', { provider: 'local', status: 'off' });
+          send('capture:state', { active: false, streaming: false, mode: 'local' });
+          return false;
+        }
+        send('stt:status', { provider: 'local', status: 'error' });
+        send('status', { message: `Local transcription could not start: ${error.message} No audio was sent to a cloud provider.` });
+        send('capture:state', { active: false, streaming: false, mode: 'local' });
+        return false;
+      }
+    }
+
+    state.capturing = true;
     // Try streaming first, fall back to batch
     const streaming = initStreamingSTT();
     if (!streaming) {
       startFlushLoop();
     }
     console.log('[cue] capture started, mode:', streaming ? 'streaming' : 'batch');
-  } else {
-    stopFlushLoop();
-    stopStreamingSTT();
-    buffers.you = []; buffers.them = [];
-    vad.you.reset(); vad.them.reset();
-    ringBuffers.you.clear(); ringBuffers.them.clear();
+    send('capture:state', { active: true, streaming: streamingMode, mode: streaming ? 'streaming' : 'batch' });
+    return true;
   }
-  send('capture:state', { active, streaming: streamingMode });
-  return active;
+
+  state.capturing = false;
+  stopFlushLoop();
+  stopStreamingSTT();
+  buffers.you = []; buffers.them = [];
+  vad.you.reset(); vad.them.reset();
+  ringBuffers.you.clear(); ringBuffers.them.clear();
+  const stoppingLocalTranscriber = localWhisperTranscriber;
+  localWhisperTranscriber = null;
+  send('capture:state', { active: false, streaming: false, mode: stoppingLocalTranscriber ? 'local' : 'off' });
+  if (stoppingLocalTranscriber) {
+    send('stt:status', { provider: 'local', status: 'stopping' });
+    try {
+      await stoppingLocalTranscriber.stop();
+    } catch (error) {
+      console.log('[local-whisper] stop error', error && error.message);
+    } finally {
+      activeWhisperModelId = null;
+    }
+  }
+  return false;
 }
 
 // -------- feature runner --------
@@ -362,8 +494,54 @@ async function runFeature(mode, userText) {
 // -------- IPC --------
 ipcMain.handle('settings:get', () => store.getSettings());
 ipcMain.handle('settings:set', (_e, patch) => { sttDisabled = false; return store.setSettings(patch); });
-ipcMain.handle('capture:toggle', () => setCapturing(!state.capturing));
+ipcMain.handle('capture:toggle', () => {
+  const targetState = !desiredCaptureState;
+  desiredCaptureState = targetState;
+  if (!targetState && !state.capturing && localWhisperTranscriber) {
+    localWhisperTranscriber.forceStop().catch(() => {});
+  }
+  captureTransition = captureTransition
+    .catch(() => state.capturing)
+    .then(() => setCapturing(targetState));
+  return captureTransition;
+});
 ipcMain.handle('capture:state', () => ({ active: state.capturing }));
+ipcMain.handle('whisper:models', () => getWhisperOverview());
+ipcMain.handle('whisper:model-download', async (_event, modelId) => {
+  if (!whisperModelManager) throw new Error('The local Whisper model manager is not ready.');
+  const result = await whisperModelManager.download(modelId, (progress) => send('whisper:download-progress', progress));
+  send('whisper:models-changed', { modelId });
+  return result;
+});
+ipcMain.handle('whisper:model-cancel', (_event, modelId) => {
+  if (!whisperModelManager) return false;
+  return whisperModelManager.cancelDownload(modelId);
+});
+ipcMain.handle('whisper:model-delete', async (_event, modelId) => {
+  requireWhisperModel(modelId);
+  if (activeWhisperModelId === modelId) {
+    throw new Error('Stop listening before deleting the active model.');
+  }
+  const result = await whisperModelManager.deleteModel(modelId);
+  send('whisper:models-changed', { modelId });
+  return result;
+});
+ipcMain.handle('whisper:model-import', async (_event, modelId) => {
+  if (!whisperModelManager) throw new Error('The local Whisper model manager is not ready.');
+  requireWhisperModel(modelId);
+  if (activeWhisperModelId === modelId) {
+    throw new Error('Stop listening before replacing the active model.');
+  }
+  const selection = await dialog.showOpenDialog(win, {
+    title: `Import ggml-${modelId}.bin`,
+    properties: ['openFile'],
+    filters: [{ name: 'whisper.cpp model', extensions: ['bin'] }]
+  });
+  if (selection.canceled || !selection.filePaths[0]) return { cancelled: true };
+  const result = await whisperModelManager.importModel(modelId, selection.filePaths[0]);
+  send('whisper:models-changed', { modelId });
+  return result;
+});
 ipcMain.handle('platform:info', () => ({
   platform: process.platform,
   winBuild: WIN_BUILD,
@@ -397,6 +575,8 @@ app.whenReady().then(() => {
 
   if (isMac && app.dock) app.dock.hide();
 
+  whisperModelManager = new WhisperModelManager({ userDataPath: app.getPath('userData') });
+
   const allowMedia = (permission) => permission === 'media' || permission === 'microphone' || permission === 'audioCapture' || permission === 'display-capture' || permission === 'screen';
   session.defaultSession.setPermissionRequestHandler((_wc, permission, cb) => cb(allowMedia(permission)));
   session.defaultSession.setPermissionCheckHandler((_wc, permission) => allowMedia(permission));
@@ -419,5 +599,11 @@ app.whenReady().then(() => {
   app.on('activate', () => { if (BrowserWindow.getAllWindows().length === 0) createWindow(); });
 });
 
-app.on('will-quit', () => { globalShortcut.unregisterAll(); });
+app.on('will-quit', () => {
+  globalShortcut.unregisterAll();
+  if (whisperModelManager?.activeDownload) {
+    whisperModelManager.cancelDownload(whisperModelManager.activeDownload.modelId);
+  }
+  if (localWhisperTranscriber) localWhisperTranscriber.forceStop().catch(() => {});
+});
 app.on('window-all-closed', () => app.quit());

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cue",
-  "version": "0.1.0",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cue",
-      "version": "0.1.0",
+      "version": "0.2.2",
       "hasInstallScript": true,
       "license": "GPL-3.0-or-later",
       "dependencies": {
@@ -19,8 +19,12 @@
       "devDependencies": {
         "electron": "33.2.1",
         "electron-builder": "^24.13.3",
-        "rcedit": "^5.0.2",
-        "resedit": "^3.0.2"
+        "extract-zip": "^2.0.1",
+        "resedit": "^3.0.2",
+        "tar": "^7.5.22"
+      },
+      "engines": {
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@anthropic-ai/sdk": {
@@ -416,6 +420,29 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass/node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
     "node_modules/@malept/cross-spawn-promise": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-1.1.1.tgz",
@@ -779,6 +806,16 @@
         "electron-builder-squirrel-windows": "24.13.3"
       }
     },
+    "node_modules/app-builder-lib/node_modules/chownr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/app-builder-lib/node_modules/fs-extra": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
@@ -805,6 +842,33 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/app-builder-lib/node_modules/minizlib": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/minizlib/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/app-builder-lib/node_modules/semver": {
       "version": "7.8.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
@@ -812,6 +876,25 @@
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/tar": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+      "deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^5.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
       },
       "engines": {
         "node": ">=10"
@@ -1241,12 +1324,13 @@
       }
     },
     "node_modules/chownr": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
       "dev": true,
+      "license": "BlueOak-1.0.0",
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       }
     },
     "node_modules/chromium-pickle-js": {
@@ -1492,31 +1576,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/cross-spawn-windows-exe": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/cross-spawn-windows-exe/-/cross-spawn-windows-exe-1.2.0.tgz",
-      "integrity": "sha512-mkLtJJcYbDCxEG7Js6eUnUNndWjyUZwJ3H7bErmmtOYU/Zb99DyUkpamuIZE0b3bhmJyZ7D90uS6f+CGxRRjOw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/malept"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/subscription/pkg/npm-cross-spawn-windows-exe?utm_medium=referral&utm_source=npm_fund"
-        }
-      ],
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@malept/cross-spawn-promise": "^1.1.0",
-        "is-wsl": "^2.2.0",
-        "which": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 10"
       }
     },
     "node_modules/debug": {
@@ -2102,6 +2161,7 @@
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
       "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "debug": "^4.1.1",
         "get-stream": "^5.1.0",
@@ -2231,6 +2291,7 @@
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
       "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "minipass": "^3.0.0"
       },
@@ -2243,6 +2304,7 @@
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
       "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -2733,22 +2795,6 @@
         "is-ci": "bin.js"
       }
     },
-    "node_modules/is-docker": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
-      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "is-docker": "cli.js"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -2767,19 +2813,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/is-wsl": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
-      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-docker": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/isarray": {
@@ -3148,28 +3181,26 @@
       }
     },
     "node_modules/minizlib": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "minipass": "^3.0.0",
-        "yallist": "^4.0.0"
+        "minipass": "^7.1.2"
       },
       "engines": {
-        "node": ">= 8"
+        "node": ">= 18"
       }
     },
     "node_modules/minizlib/node_modules/minipass": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
       "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
+      "license": "BlueOak-1.0.0",
       "engines": {
-        "node": ">=8"
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/mkdirp": {
@@ -3177,6 +3208,7 @@
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "mkdirp": "bin/cmd.js"
       },
@@ -3457,20 +3489,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/rcedit": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/rcedit/-/rcedit-5.0.2.tgz",
-      "integrity": "sha512-dgysxaeXZ4snLpPjn8aVtHvZDCx+aRcvZbaWBgl1poU6OPustMvOkj9a9ZqASQ6i5Y5szJ13LSvglEOwrmgUxA==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cross-spawn-windows-exe": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 22.12.0"
       }
     },
     "node_modules/read-config-file": {
@@ -3868,21 +3886,20 @@
       }
     },
     "node_modules/tar": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
-      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
-      "deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
       "dev": true,
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.0.0",
-        "minipass": "^5.0.0",
-        "minizlib": "^2.1.1",
-        "mkdirp": "^1.0.3",
-        "yallist": "^4.0.0"
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       }
     },
     "node_modules/tar-stream": {
@@ -3900,6 +3917,26 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/tar/node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/tar/node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/temp-file": {

--- a/package.json
+++ b/package.json
@@ -9,41 +9,14 @@
     "start": "electron .",
     "test": "node --test test/*.test.js",
     "postinstall": "node scripts/rename-electron.js",
-    "pack": "electron-builder --dir",
-    "dist": "electron-builder --mac zip",
-    "dist:mac": "electron-builder --mac zip",
-    "dist:win": "electron-builder --win zip"
-  },
-  "build": {
-    "appId": "com.cue.overlay",
-    "productName": "cue",
-    "asar": false,
-    "files": [
-      "main.js",
-      "preload.js",
-      "src/**/*",
-      "renderer/**/*"
-    ],
-    "mac": {
-      "target": [
-        "dir"
-      ],
-      "category": "public.app-category.productivity",
-      "hardenedRuntime": false,
-      "gatekeeperAssess": false,
-      "identity": null,
-      "extendInfo": {
-        "LSUIElement": true,
-        "NSMicrophoneUsageDescription": "cue transcribes your microphone so it can help you in conversations.",
-        "NSCameraUsageDescription": "cue does not use the camera.",
-        "NSAudioCaptureUsageDescription": "cue captures system audio to transcribe the other participant in a call."
-      }
-    },
-    "win": {
-      "target": [
-        "dir"
-      ]
-    }
+    "prepare:whisper": "node scripts/prepare-whisper-runtime.js",
+    "verify:whisper-runtime": "node scripts/verify-whisper-runtime.js",
+    "pack": "electron-builder --config electron-builder.cjs --dir",
+    "dist": "npm run dist:mac",
+    "dist:mac": "electron-builder --config electron-builder.cjs --mac zip",
+    "dist:win": "electron-builder --config electron-builder.cjs --win nsis",
+    "dist:linux": "electron-builder --config electron-builder.cjs --linux AppImage --x64",
+    "dist:linux:arm64": "electron-builder --config electron-builder.cjs --linux AppImage --arm64"
   },
   "keywords": [
     "electron",
@@ -56,7 +29,9 @@
   "devDependencies": {
     "electron": "33.2.1",
     "electron-builder": "^24.13.3",
-    "resedit": "^3.0.2"
+    "extract-zip": "^2.0.1",
+    "resedit": "^3.0.2",
+    "tar": "^7.5.22"
   },
   "engines": {
     "node": ">=22.12.0"

--- a/preload.js
+++ b/preload.js
@@ -5,6 +5,11 @@ contextBridge.exposeInMainWorld('cue', {
   platform,
   settingsGet: () => ipcRenderer.invoke('settings:get'),
   settingsSet: (patch) => ipcRenderer.invoke('settings:set', patch),
+  whisperModels: () => ipcRenderer.invoke('whisper:models'),
+  whisperModelDownload: (modelId) => ipcRenderer.invoke('whisper:model-download', modelId),
+  whisperModelCancel: (modelId) => ipcRenderer.invoke('whisper:model-cancel', modelId),
+  whisperModelDelete: (modelId) => ipcRenderer.invoke('whisper:model-delete', modelId),
+  whisperModelImport: (modelId) => ipcRenderer.invoke('whisper:model-import', modelId),
   platformInfo: () => ipcRenderer.invoke('platform:info'),
   ask: (payload) => ipcRenderer.send('ask', payload),
   captureToggle: () => ipcRenderer.invoke('capture:toggle').catch((err) => {
@@ -19,7 +24,7 @@ contextBridge.exposeInMainWorld('cue', {
   openPane: (url) => ipcRenderer.send('open-pane', url),
   log: (msg) => ipcRenderer.send('log', msg),
   on: (channel, cb) => {
-    const allowed = ['capture:state', 'llm:start', 'llm:token', 'llm:done', 'llm:error', 'status', 'transcript', 'stt:interim', 'stt:final', 'stt:status', 'vad:state'];
+    const allowed = ['capture:state', 'llm:start', 'llm:token', 'llm:done', 'llm:error', 'status', 'transcript', 'stt:interim', 'stt:final', 'stt:status', 'vad:state', 'whisper:download-progress', 'whisper:models-changed'];
     if (!allowed.includes(channel)) return;
     ipcRenderer.on(channel, (_e, data) => cb(data));
   }

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -88,6 +88,7 @@
       <!-- Tab bar -->
       <div class="s-tabs">
         <button class="s-tab on" data-tab="keys">🔑 Keys</button>
+        <button class="s-tab" data-tab="transcription">Audio</button>
         <button class="s-tab" data-tab="profile">📄 Profile</button>
         <button class="s-tab" data-tab="prep">🎯 Interview Prep</button>
         <button class="s-tab" data-tab="qa">💬 Q&amp;A</button>
@@ -113,6 +114,57 @@
         <div class="s-field"><span>Smart</span><input id="model-smart" type="text" autocomplete="off" /></div>
 
         <div class="s-status" id="s-status"></div>
+      </div>
+
+      <!-- Tab: Transcription -->
+      <div class="s-body s-tab-pane hidden" data-pane="transcription">
+        <label class="s-label">Speech-to-text provider</label>
+        <div class="s-seg s-seg-wrap" id="stt-provider-seg">
+          <button data-stt-provider="auto">Auto</button>
+          <button data-stt-provider="local">Local</button>
+          <button data-stt-provider="deepgram">Deepgram</button>
+          <button data-stt-provider="openai">OpenAI</button>
+          <button data-stt-provider="gemini">Gemini</button>
+        </div>
+        <div class="s-note">Local mode keeps microphone and meeting audio on this computer. It never silently falls back to a cloud transcription provider.</div>
+
+        <div class="whisper-card">
+          <div class="whisper-runtime-row">
+            <span class="s-label">whisper.cpp runtime</span>
+            <span id="whisper-runtime-status" class="whisper-badge">Checking…</span>
+          </div>
+
+          <label class="s-label" for="whisper-model">Local model</label>
+          <select id="whisper-model" class="s-select"></select>
+          <div id="whisper-model-detail" class="s-note"></div>
+
+          <div id="whisper-progress-wrap" class="whisper-progress-wrap hidden">
+            <progress id="whisper-progress" max="100" value="0"></progress>
+            <span id="whisper-progress-label">0%</span>
+          </div>
+
+          <div class="whisper-actions">
+            <button id="whisper-download" class="s-action">Download</button>
+            <button id="whisper-cancel" class="s-action hidden">Cancel</button>
+            <button id="whisper-import" class="s-action">Import…</button>
+            <button id="whisper-delete" class="s-action danger" disabled>Delete</button>
+          </div>
+
+          <div class="s-field">
+            <span>Language</span>
+            <select id="whisper-language" class="s-select compact">
+              <option value="auto">Auto-detect</option>
+              <option value="en">English</option>
+            </select>
+          </div>
+          <div class="s-field">
+            <span>CPU threads</span>
+            <input id="whisper-threads" type="number" min="0" max="64" step="1" value="0" />
+          </div>
+          <div class="s-note">Use 0 for whisper.cpp's default. English-only models always use English regardless of the language setting.</div>
+        </div>
+
+        <div class="s-status" id="whisper-status"></div>
       </div>
 
       <!-- Tab: Profile -->

--- a/renderer/renderer.js
+++ b/renderer/renderer.js
@@ -24,6 +24,7 @@
 
   // ---- state -------------------------------------------------------------
   let settings = null;
+  let whisperOverview = null;
   let busy = false;
   let aiEl = null;       // current streaming <div class="ai-text">
   let caretEl = null;
@@ -208,7 +209,8 @@
     if (turningOn) {
       await startSystemAudio();
     }
-    await cue.captureToggle();
+    const active = await cue.captureToggle();
+    if (turningOn && !active) stopSystemAudio();
   });
 
   // Transcript toggle
@@ -413,14 +415,20 @@
   }
 
   // ---- events from main --------------------------------------------------
-  cue.on('capture:state', ({ active, streaming }) => {
+  cue.on('capture:state', ({ active, streaming, mode }) => {
     setLiveDotState(active ? 'idle' : 'off');
     $('#stop-btn').classList.toggle('active', active);
     // startSystemAudio() is called directly from the stop-button click handler
     // so that the getDisplayMedia request has a fresh user gesture.
     // Here we only start the mic (no gesture required) and stop everything on deactivate.
     if (active) { startMic(); } else { stopMic(); stopSystemAudio(); }
-    updateSttStatus({ active, streaming });
+    if (active && mode === 'local') {
+      sttState = 'local';
+      const label = document.getElementById('stt-status');
+      if (label) { label.textContent = 'local'; label.className = 'stt-status stt-local'; }
+    } else {
+      updateSttStatus({ active, streaming });
+    }
   });
 
   // ---- real-time transcript display (interim + final) ----
@@ -449,8 +457,30 @@
     if (interimEl) { interimEl.textContent = ''; interimEl.classList.remove('show'); }
     clearTranscriptInterim();
   });
-  cue.on('stt:status', ({ channel, status }) => {
-    cue.log(`[stt] ${channel} ${status}`);
+  cue.on('stt:status', ({ channel, status, provider }) => {
+    cue.log(`[stt] ${provider || channel || 'unknown'} ${status}`);
+    if (provider === 'local') {
+      const label = document.getElementById('stt-status');
+      const localLabels = {
+        loading: 'loading local',
+        ready: 'local',
+        transcribing: 'local',
+        stopping: 'stopping',
+        off: 'off',
+        error: 'error'
+      };
+      sttState = status === 'ready' || status === 'transcribing' ? 'local' : status;
+      if (label) {
+        label.textContent = localLabels[status] || status;
+        label.className = 'stt-status stt-' + sttState;
+      }
+      if (status === 'loading') $('#stop-btn').classList.add('active');
+      if (status === 'off' || status === 'error') $('#stop-btn').classList.remove('active');
+      if (status === 'loading' || status === 'transcribing' || status === 'stopping') setLiveDotState('transcribing');
+      if (status === 'ready') setLiveDotState('idle');
+      if (status === 'off') setLiveDotState('off');
+      return;
+    }
     if (status === 'connected') {
       sttState = 'streaming';
       const label = document.getElementById('stt-status');
@@ -562,7 +592,11 @@
 
   // ---- settings ----------------------------------------------------------
   const scrim = $('#settings-scrim');
-  function openSettings() { fillSettings(); scrim.classList.remove('hidden'); }
+  function openSettings() {
+    fillSettings();
+    scrim.classList.remove('hidden');
+    refreshWhisperModels();
+  }
   function closeSettings() { saveSettings(); scrim.classList.add('hidden'); }
   $('#more-btn').addEventListener('click', openSettings);
   $('#s-close').addEventListener('click', closeSettings);
@@ -592,6 +626,13 @@
     const m = settings.models[settings.provider] || { fast: '', smart: '' };
     $('#model-fast').value = m.fast; $('#model-smart').value = m.smart;
     $('#s-status').textContent = statusText();
+    // Transcription tab
+    document.querySelectorAll('#stt-provider-seg button').forEach((button) => {
+      button.classList.toggle('on', button.dataset.sttProvider === (settings.sttProvider || 'auto'));
+    });
+    const localWhisper = settings.localWhisper || { modelId: 'base.en', language: 'auto', threads: 0 };
+    $('#whisper-language').value = localWhisper.language || 'auto';
+    $('#whisper-threads').value = Number(localWhisper.threads) || 0;
     // Profile tab
     $('#resume-text').value = settings.resumeText || '';
     $('#job-description').value = settings.jobDescription || '';
@@ -607,8 +648,9 @@
 
   function statusText() {
     const k = settings.apiKeys;
-    const has = [k.openai && 'OpenAI', k.anthropic && 'Anthropic', k.gemini && 'Gemini', k.deepgram && 'Deepgram'].filter(Boolean);
-    const stt = k.deepgram ? 'Deepgram (streaming)' : (k.openai ? 'OpenAI Realtime' : (k.gemini ? 'Gemini (batch)' : 'none'));
+    const selectedSttProvider = settings.sttProvider || 'auto';
+    const automaticStt = k.deepgram ? 'Deepgram (streaming)' : (k.openai ? 'OpenAI Realtime' : (k.gemini ? 'Gemini (batch)' : 'none'));
+    const stt = selectedSttProvider === 'auto' ? automaticStt : selectedSttProvider;
     const ready = [
       settings.resumeText ? '✓ resume' : null,
       settings.jobDescription ? '✓ JD' : null,
@@ -627,6 +669,154 @@
     updateSmartTooltip();
   }));
 
+  document.querySelectorAll('#stt-provider-seg button').forEach((button) => button.addEventListener('click', () => {
+    settings.sttProvider = button.dataset.sttProvider;
+    document.querySelectorAll('#stt-provider-seg button').forEach((candidate) => {
+      candidate.classList.toggle('on', candidate === button);
+    });
+    $('#s-status').textContent = statusText();
+  }));
+
+  function formatBytes(bytes) {
+    if (!Number.isFinite(bytes) || bytes <= 0) return '0 MB';
+    const units = ['B', 'KB', 'MB', 'GB'];
+    const unitIndex = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
+    const value = bytes / (1024 ** unitIndex);
+    return `${value >= 10 || unitIndex < 2 ? value.toFixed(0) : value.toFixed(1)} ${units[unitIndex]}`;
+  }
+
+  function getSelectedWhisperModel() {
+    if (!whisperOverview) return null;
+    return whisperOverview.models.find((model) => model.id === $('#whisper-model').value) || null;
+  }
+
+  function renderWhisperModelState() {
+    const model = getSelectedWhisperModel();
+    if (!model) return;
+    const language = model.englishOnly ? 'English only' : 'Multilingual';
+    const recommendation = model.recommended ? ' · recommended default' : '';
+    const partial = model.partialBytes > 0 && !model.installed
+      ? ` · ${formatBytes(model.partialBytes)} ready to resume`
+      : '';
+    $('#whisper-model-detail').textContent = `${formatBytes(model.bytes)} · ${language} · ${model.quantization} · ${model.hardwareTier}${recommendation}${partial}`;
+
+    const progressWrap = $('#whisper-progress-wrap');
+    const progressPercent = model.bytes > 0 ? Math.floor((model.partialBytes / model.bytes) * 100) : 0;
+    progressWrap.classList.toggle('hidden', !model.downloading);
+    $('#whisper-progress').value = progressPercent;
+    $('#whisper-progress-label').textContent = `${progressPercent}%`;
+    $('#whisper-download').disabled = model.installed || model.downloading;
+    $('#whisper-download').textContent = model.installed ? 'Installed' : (model.partialBytes ? 'Resume' : 'Download');
+    $('#whisper-cancel').classList.toggle('hidden', !model.downloading);
+    $('#whisper-import').disabled = model.downloading;
+    $('#whisper-delete').disabled = (model.installedBytes === 0 && model.partialBytes === 0) || model.downloading;
+  }
+
+  async function refreshWhisperModels() {
+    const status = $('#whisper-status');
+    try {
+      const previousSelection = $('#whisper-model').value || settings.localWhisper?.modelId || 'base.en';
+      whisperOverview = await cue.whisperModels();
+      const runtimeBadge = $('#whisper-runtime-status');
+      runtimeBadge.classList.toggle('ready', whisperOverview.runtime.available);
+      runtimeBadge.classList.toggle('error', !whisperOverview.runtime.available);
+      runtimeBadge.textContent = whisperOverview.runtime.available
+        ? `Ready · v${whisperOverview.runtime.version} · ${whisperOverview.runtime.target}`
+        : 'Not prepared';
+      runtimeBadge.title = whisperOverview.runtime.message || '';
+
+      const select = $('#whisper-model');
+      select.innerHTML = '';
+      for (const model of whisperOverview.models) {
+        const option = document.createElement('option');
+        option.value = model.id;
+        option.textContent = `${model.label} — ${formatBytes(model.bytes)}${model.recommended ? ' (recommended)' : ''}${model.installed ? ' ✓' : ''}`;
+        select.appendChild(option);
+      }
+      const selectionExists = whisperOverview.models.some((model) => model.id === previousSelection);
+      select.value = selectionExists ? previousSelection : 'base.en';
+      if (!settings.localWhisper) settings.localWhisper = {};
+      settings.localWhisper.modelId = select.value;
+      status.textContent = whisperOverview.runtime.available
+        ? 'Model files are verified before they can be loaded.'
+        : whisperOverview.runtime.message;
+      renderWhisperModelState();
+    } catch (error) {
+      status.textContent = `Could not load local model information: ${error.message}`;
+    }
+  }
+
+  $('#whisper-model').addEventListener('change', () => {
+    if (!settings.localWhisper) settings.localWhisper = {};
+    settings.localWhisper.modelId = $('#whisper-model').value;
+    renderWhisperModelState();
+  });
+
+  $('#whisper-download').addEventListener('click', async () => {
+    const model = getSelectedWhisperModel();
+    if (!model) return;
+    model.downloading = true;
+    renderWhisperModelState();
+    $('#whisper-status').textContent = `Downloading ${model.id}. You can cancel and resume later.`;
+    try {
+      await cue.whisperModelDownload(model.id);
+      $('#whisper-status').textContent = `${model.id} downloaded and verified.`;
+    } catch (error) {
+      $('#whisper-status').textContent = error.message.includes('cancelled')
+        ? `${model.id} download paused. Progress was kept.`
+        : `Download failed: ${error.message}`;
+    } finally {
+      await refreshWhisperModels();
+    }
+  });
+
+  $('#whisper-cancel').addEventListener('click', async () => {
+    const model = getSelectedWhisperModel();
+    if (model) await cue.whisperModelCancel(model.id);
+  });
+
+  $('#whisper-import').addEventListener('click', async () => {
+    const model = getSelectedWhisperModel();
+    if (!model) return;
+    $('#whisper-status').textContent = `Verifying imported ${model.id}…`;
+    try {
+      const result = await cue.whisperModelImport(model.id);
+      $('#whisper-status').textContent = result.cancelled ? 'Import cancelled.' : `${model.id} imported and verified.`;
+    } catch (error) {
+      $('#whisper-status').textContent = `Import failed: ${error.message}`;
+    } finally {
+      await refreshWhisperModels();
+    }
+  });
+
+  $('#whisper-delete').addEventListener('click', async () => {
+    const model = getSelectedWhisperModel();
+    if (!model || !window.confirm(`Delete the ${model.id} model (${formatBytes(model.bytes)}) from this computer?`)) return;
+    try {
+      await cue.whisperModelDelete(model.id);
+      $('#whisper-status').textContent = `${model.id} deleted.`;
+    } catch (error) {
+      $('#whisper-status').textContent = `Delete failed: ${error.message}`;
+    } finally {
+      await refreshWhisperModels();
+    }
+  });
+
+  cue.on('whisper:download-progress', (progress) => {
+    if (!whisperOverview) return;
+    const model = whisperOverview.models.find((candidate) => candidate.id === progress.modelId);
+    if (!model) return;
+    model.partialBytes = progress.receivedBytes;
+    model.downloading = true;
+    if ($('#whisper-model').value === progress.modelId) {
+      $('#whisper-progress-wrap').classList.remove('hidden');
+      $('#whisper-progress').value = progress.percent;
+      $('#whisper-progress-label').textContent = `${progress.percent}%`;
+      $('#whisper-model-detail').textContent = `${formatBytes(progress.receivedBytes)} of ${formatBytes(progress.totalBytes)}`;
+    }
+  });
+  cue.on('whisper:models-changed', () => refreshWhisperModels());
+
   async function saveSettings() {
     // Keys
     settings.apiKeys.openai = $('#key-openai').value.trim();
@@ -636,6 +826,11 @@
     if (!settings.models[settings.provider]) settings.models[settings.provider] = {};
     settings.models[settings.provider].fast = $('#model-fast').value.trim();
     settings.models[settings.provider].smart = $('#model-smart').value.trim();
+    // Transcription
+    if (!settings.localWhisper) settings.localWhisper = {};
+    settings.localWhisper.modelId = $('#whisper-model').value || settings.localWhisper.modelId || 'base.en';
+    settings.localWhisper.language = $('#whisper-language').value || 'auto';
+    settings.localWhisper.threads = Math.max(0, Math.min(64, Number.parseInt($('#whisper-threads').value, 10) || 0));
     // Profile
     settings.resumeText = $('#resume-text').value.trim();
     settings.jobDescription = $('#job-description').value.trim();

--- a/renderer/styles.css
+++ b/renderer/styles.css
@@ -293,9 +293,9 @@ button:focus { outline: none; }
 .s-close { border: none; background: var(--accent); color: #fff; font-weight: 600; font-size: 13px; padding: 6px 14px; border-radius: var(--r-pill); cursor: pointer; }
 
 /* Tab bar */
-.s-tabs { display: flex; gap: 4px; margin-bottom: 12px; flex-shrink: 0; }
+.s-tabs { display: flex; gap: 4px; margin-bottom: 12px; flex-shrink: 0; overflow-x: auto; }
 .s-tab {
-  flex: 1; padding: 7px 4px; border-radius: var(--r-8);
+  flex: 1; min-width: 72px; padding: 7px 4px; border-radius: var(--r-8);
   border: 1px solid rgba(255,255,255,0.10); background: rgba(255,255,255,0.03);
   color: var(--tx-mut); font-size: 12px; font-weight: 500; font-family: var(--font);
   cursor: pointer; transition: all 140ms ease; white-space: nowrap;
@@ -311,12 +311,46 @@ button:focus { outline: none; }
 .s-label { color: var(--tx-2); font-size: 13px; font-weight: 600; margin-top: 6px; flex-shrink: 0; }
 .s-hint { color: var(--tx-mut); font-weight: 400; font-size: 11px; margin-left: 6px; }
 .s-seg { display: flex; gap: 6px; }
+.s-seg-wrap { flex-wrap: wrap; }
+.s-seg-wrap button { min-width: 76px; }
 .s-seg button { flex: 1; padding: 8px; border-radius: var(--r-8); border: 1px solid rgba(255,255,255,0.14); background: rgba(255,255,255,0.04); color: var(--tx-2); font-size: 13px; font-weight: 500; cursor: pointer; transition: all 140ms ease; }
 .s-seg button.on { border-color: var(--accent); color: #fff; background: rgba(60,131,245,0.16); }
 .s-field { display: flex; align-items: center; gap: 10px; }
 .s-field span { width: 78px; color: var(--tx-mut); font-size: 12px; flex-shrink: 0; }
 .s-field input { flex: 1; padding: 8px 10px; border-radius: var(--r-8); border: 1px solid rgba(255,255,255,0.14); background: rgba(0,0,0,0.25); color: var(--tx-1); font-size: 13px; font-family: var(--font); outline: none; }
 .s-field input:focus { border-color: var(--accent); }
+.s-select {
+  width: 100%; padding: 8px 10px; border-radius: var(--r-8);
+  border: 1px solid rgba(255,255,255,0.14); background: #17191f;
+  color: var(--tx-1); font-size: 13px; font-family: var(--font); outline: none;
+}
+.s-select:focus { border-color: var(--accent); }
+.s-select.compact { flex: 1; width: auto; }
+.s-note { color: var(--tx-mut); font-size: 11.5px; line-height: 1.45; }
+.whisper-card {
+  display: flex; flex-direction: column; gap: 8px; margin-top: 4px; padding: 12px;
+  border: 1px solid rgba(255,255,255,0.10); border-radius: 12px;
+  background: rgba(0,0,0,0.18);
+}
+.whisper-runtime-row { display: flex; align-items: center; justify-content: space-between; gap: 10px; }
+.whisper-runtime-row .s-label { margin: 0; }
+.whisper-badge {
+  padding: 3px 8px; border-radius: var(--r-pill); color: var(--tx-mut);
+  border: 1px solid rgba(255,255,255,0.12); font-size: 10.5px; white-space: nowrap;
+}
+.whisper-badge.ready { color: #86efac; border-color: rgba(34,197,94,0.35); background: rgba(34,197,94,0.08); }
+.whisper-badge.error { color: #fca5a5; border-color: rgba(239,68,68,0.35); background: rgba(239,68,68,0.08); }
+.whisper-progress-wrap { display: flex; align-items: center; gap: 8px; }
+.whisper-progress-wrap progress { flex: 1; height: 8px; accent-color: var(--accent); }
+.whisper-progress-wrap span { width: 42px; color: var(--tx-mut); font-size: 11px; text-align: right; }
+.whisper-actions { display: flex; flex-wrap: wrap; gap: 6px; }
+.s-action {
+  padding: 6px 10px; border-radius: var(--r-8); border: 1px solid rgba(255,255,255,0.14);
+  background: rgba(255,255,255,0.05); color: var(--tx-2); font: 500 12px var(--font); cursor: pointer;
+}
+.s-action:hover:not(:disabled) { color: #fff; background: rgba(255,255,255,0.09); }
+.s-action:disabled { opacity: 0.4; cursor: default; }
+.s-action.danger:hover:not(:disabled) { color: #fca5a5; border-color: rgba(239,68,68,0.35); background: rgba(239,68,68,0.08); }
 /* Textareas inside settings */
 #settings textarea {
   width: 100%; padding: 8px 10px; border-radius: var(--r-8);
@@ -418,6 +452,9 @@ button:focus { outline: none; }
 .stt-disconnected { color: rgba(255,255,255,0.25); }
 .stt-connecting   { color: #facc15; }
 .stt-streaming    { color: var(--live); }
+.stt-local        { color: var(--live); }
+.stt-loading      { color: #facc15; }
+.stt-stopping     { color: #facc15; }
 .stt-batch        { color: rgba(160,210,255,0.7); }
 .stt-error        { color: #fca5a5; }
 

--- a/scripts/after-pack.js
+++ b/scripts/after-pack.js
@@ -1,0 +1,13 @@
+const path = require('path');
+const { Arch } = require('builder-util');
+const { prepareWhisperRuntime } = require('./prepare-whisper-runtime');
+
+/** Add the matching native runtime after Electron has assembled each target. */
+module.exports = async function afterPack(context) {
+  const platform = context.packager.platform.nodeName;
+  const architecture = typeof context.arch === 'number' ? Arch[context.arch] : context.arch;
+  if (!platform || !architecture) throw new Error('electron-builder did not provide a runtime target.');
+
+  const outputDirectory = path.join(context.appOutDir, 'resources', 'whisper-runtime');
+  await prepareWhisperRuntime({ platform, architecture, outputDirectory });
+};

--- a/scripts/prepare-whisper-runtime.js
+++ b/scripts/prepare-whisper-runtime.js
@@ -1,0 +1,296 @@
+#!/usr/bin/env node
+
+const crypto = require('crypto');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execFileSync } = require('child_process');
+const extractZip = require('extract-zip');
+const tar = require('tar');
+const {
+  WHISPER_CPP_VERSION,
+  SOURCE_ARCHIVE_SHA256,
+  getRuntimeTarget,
+  getRuntimeExecutablePath
+} = require('../src/whisper-runtime-manifest');
+
+const PROJECT_ROOT = path.resolve(__dirname, '..');
+const DEFAULT_CACHE_ROOT = path.join(PROJECT_ROOT, '.cache', 'whisper-runtime');
+const LICENSE_PATH = path.join(PROJECT_ROOT, 'build-resources', 'whisper.cpp.LICENSE');
+const RUNTIME_MANIFEST_FILENAME = 'runtime.json';
+
+function readArgument(name) {
+  const index = process.argv.indexOf(`--${name}`);
+  return index >= 0 ? process.argv[index + 1] : null;
+}
+
+function assertSafeManagedDirectory(targetPath, parentPath) {
+  const resolvedTarget = path.resolve(targetPath);
+  const resolvedParent = path.resolve(parentPath);
+  const relativePath = path.relative(resolvedParent, resolvedTarget);
+  if (!relativePath || relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
+    throw new Error(`Refusing to replace unmanaged directory: ${resolvedTarget}`);
+  }
+}
+
+async function sha256(filePath) {
+  const hash = crypto.createHash('sha256');
+  for await (const chunk of fs.createReadStream(filePath)) hash.update(chunk);
+  return hash.digest('hex');
+}
+
+async function downloadArtifact(url, destinationPath, expectedBytes, expectedSha256) {
+  const response = await fetch(url, { redirect: 'follow' });
+  if (!response.ok || !response.body) throw new Error(`Download failed with HTTP ${response.status}: ${url}`);
+
+  const output = fs.createWriteStream(destinationPath, { flags: 'wx' });
+  try {
+    for await (const chunk of response.body) {
+      if (!output.write(Buffer.from(chunk))) {
+        await new Promise((resolve) => output.once('drain', resolve));
+      }
+    }
+  } finally {
+    await new Promise((resolve, reject) => output.end((error) => error ? reject(error) : resolve()));
+  }
+
+  const fileStats = await fs.promises.stat(destinationPath);
+  if (expectedBytes && fileStats.size !== expectedBytes) {
+    throw new Error(`Artifact size mismatch: expected ${expectedBytes}, received ${fileStats.size}.`);
+  }
+  const actualSha256 = await sha256(destinationPath);
+  if (actualSha256 !== expectedSha256) throw new Error('Artifact checksum verification failed.');
+}
+
+async function findFile(rootDirectory, filename) {
+  const pendingDirectories = [rootDirectory];
+  while (pendingDirectories.length > 0) {
+    const currentDirectory = pendingDirectories.pop();
+    const entries = await fs.promises.readdir(currentDirectory, { withFileTypes: true });
+    for (const entry of entries) {
+      const entryPath = path.join(currentDirectory, entry.name);
+      if (entry.isDirectory()) pendingDirectories.push(entryPath);
+      if (entry.isFile() && entry.name === filename) return entryPath;
+    }
+  }
+  throw new Error(`Could not find ${filename} in the prepared whisper.cpp files.`);
+}
+
+function shouldCopyRuntimeEntry(filename, executableName) {
+  return filename === executableName ||
+    filename === 'LICENSE' ||
+    filename.endsWith('.dll') ||
+    filename.endsWith('.dylib') ||
+    filename.includes('.so');
+}
+
+async function copyRuntimeDependencies(sourceDirectory, executableName, destinationDirectory) {
+  await fs.promises.mkdir(destinationDirectory, { recursive: true });
+  const entries = await fs.promises.readdir(sourceDirectory, { withFileTypes: true });
+  for (const entry of entries) {
+    if (!shouldCopyRuntimeEntry(entry.name, executableName)) continue;
+    const sourcePath = path.join(sourceDirectory, entry.name);
+    const destinationPath = path.join(destinationDirectory, entry.name);
+    await fs.promises.cp(sourcePath, destinationPath, { recursive: false, dereference: false });
+  }
+  await fs.promises.copyFile(LICENSE_PATH, path.join(destinationDirectory, 'whisper.cpp.LICENSE'));
+  if (process.platform !== 'win32') {
+    await fs.promises.chmod(path.join(destinationDirectory, executableName), 0o755);
+  }
+}
+
+async function prepareArchiveTarget(target, temporaryDirectory, destinationDirectory) {
+  const archivePath = path.join(temporaryDirectory, target.filename);
+  const extractionDirectory = path.join(temporaryDirectory, 'extracted');
+  await fs.promises.mkdir(extractionDirectory, { recursive: true });
+  await downloadArtifact(target.url, archivePath, target.bytes, target.sha256);
+
+  if (target.archiveType === 'zip') {
+    await extractZip(archivePath, { dir: extractionDirectory });
+  } else {
+    await extractTarWithMaterializedLinks(archivePath, extractionDirectory);
+  }
+
+  const executablePath = await findFile(extractionDirectory, target.executable);
+  await copyRuntimeDependencies(path.dirname(executablePath), target.executable, destinationDirectory);
+}
+
+function resolveArchivePath(extractionDirectory, archivePath) {
+  if (!archivePath || path.posix.isAbsolute(archivePath)) {
+    throw new Error(`Unsafe archive path: ${archivePath}`);
+  }
+  const normalizedArchivePath = path.posix.normalize(archivePath);
+  if (normalizedArchivePath === '..' || normalizedArchivePath.startsWith('../')) {
+    throw new Error(`Unsafe archive path: ${archivePath}`);
+  }
+  const resolvedPath = path.resolve(extractionDirectory, ...normalizedArchivePath.split('/'));
+  const resolvedRoot = path.resolve(extractionDirectory);
+  if (!resolvedPath.startsWith(`${resolvedRoot}${path.sep}`)) {
+    throw new Error(`Archive path escaped extraction root: ${archivePath}`);
+  }
+  return resolvedPath;
+}
+
+// Time O(e + l²), space O(l): l is only the archive's small symlink alias set.
+async function extractTarWithMaterializedLinks(archivePath, extractionDirectory) {
+  const symbolicLinks = [];
+  await tar.t({
+    file: archivePath,
+    onentry(entry) {
+      if (entry.type === 'SymbolicLink') {
+        symbolicLinks.push({ archivePath: entry.path, linkPath: entry.linkpath });
+      }
+    }
+  });
+
+  await tar.x({
+    file: archivePath,
+    cwd: extractionDirectory,
+    strict: true,
+    filter: (_entryPath, entry) => entry.type !== 'SymbolicLink'
+  });
+
+  const linkByArchivePath = new Map(symbolicLinks.map((link) => [link.archivePath, link]));
+  for (const link of symbolicLinks) {
+    let targetArchivePath = path.posix.normalize(path.posix.join(path.posix.dirname(link.archivePath), link.linkPath));
+    const visitedPaths = new Set([link.archivePath]);
+    while (linkByArchivePath.has(targetArchivePath)) {
+      if (visitedPaths.has(targetArchivePath)) throw new Error(`Cyclic archive link: ${link.archivePath}`);
+      visitedPaths.add(targetArchivePath);
+      const targetLink = linkByArchivePath.get(targetArchivePath);
+      targetArchivePath = path.posix.normalize(path.posix.join(path.posix.dirname(targetLink.archivePath), targetLink.linkPath));
+    }
+
+    const sourcePath = resolveArchivePath(extractionDirectory, targetArchivePath);
+    const destinationPath = resolveArchivePath(extractionDirectory, link.archivePath);
+    await fs.promises.copyFile(sourcePath, destinationPath);
+  }
+}
+
+function runCMake(argumentsList, workingDirectory) {
+  execFileSync('cmake', argumentsList, {
+    cwd: workingDirectory,
+    env: process.env,
+    stdio: 'inherit',
+    windowsHide: true
+  });
+}
+
+async function prepareMacTarget(target, temporaryDirectory, destinationDirectory) {
+  if (process.platform !== 'darwin') {
+    throw new Error(`The ${target.key} runtime must be compiled on macOS.`);
+  }
+
+  const sourceArchivePath = path.join(temporaryDirectory, `whisper.cpp-${WHISPER_CPP_VERSION}.zip`);
+  const sourceExtractionDirectory = path.join(temporaryDirectory, 'source');
+  const buildDirectory = path.join(temporaryDirectory, 'build');
+  await fs.promises.mkdir(sourceExtractionDirectory, { recursive: true });
+  await downloadArtifact(target.url, sourceArchivePath, null, SOURCE_ARCHIVE_SHA256);
+  await extractZip(sourceArchivePath, { dir: sourceExtractionDirectory });
+  const sourceDirectory = path.dirname(await findFile(sourceExtractionDirectory, 'CMakeLists.txt'));
+
+  runCMake([
+    '-S', sourceDirectory,
+    '-B', buildDirectory,
+    '-DCMAKE_BUILD_TYPE=Release',
+    `-DCMAKE_OSX_ARCHITECTURES=${target.sourceArchitecture}`,
+    '-DCMAKE_OSX_DEPLOYMENT_TARGET=11.0',
+    '-DBUILD_SHARED_LIBS=OFF',
+    '-DGGML_NATIVE=OFF',
+    '-DWHISPER_BUILD_TESTS=OFF',
+    '-DWHISPER_BUILD_EXAMPLES=ON',
+    '-DWHISPER_BUILD_SERVER=ON',
+    '-DWHISPER_BUILD_TOOLS=OFF'
+  ], temporaryDirectory);
+  runCMake([
+    '--build', buildDirectory,
+    '--config', 'Release',
+    '--target', 'whisper-server',
+    '--parallel', String(Math.max(1, Math.min(os.cpus().length, 6)))
+  ], temporaryDirectory);
+
+  const executablePath = await findFile(buildDirectory, target.executable);
+  await copyRuntimeDependencies(path.dirname(executablePath), target.executable, destinationDirectory);
+}
+
+async function hasCurrentRuntime(runtimeDirectory, target) {
+  const executablePath = getRuntimeExecutablePath(runtimeDirectory, target.key.split('-')[0], target.key.split('-').slice(1).join('-'));
+  try {
+    const metadata = JSON.parse(await fs.promises.readFile(path.join(runtimeDirectory, RUNTIME_MANIFEST_FILENAME), 'utf8'));
+    await fs.promises.access(executablePath, fs.constants.X_OK);
+    return metadata.version === WHISPER_CPP_VERSION && metadata.target === target.key;
+  } catch {
+    return false;
+  }
+}
+
+async function replaceManagedDirectory(sourceDirectory, destinationDirectory, parentDirectory) {
+  assertSafeManagedDirectory(destinationDirectory, parentDirectory);
+  await fs.promises.mkdir(parentDirectory, { recursive: true });
+  await fs.promises.rm(destinationDirectory, { recursive: true, force: true });
+  await fs.promises.cp(sourceDirectory, destinationDirectory, { recursive: true, dereference: false });
+}
+
+/** Prepare a checksum-pinned runtime, using a per-platform cache across builds. */
+async function prepareWhisperRuntime({
+  platform = process.platform,
+  architecture = process.arch,
+  cacheRoot = DEFAULT_CACHE_ROOT,
+  outputDirectory = null
+} = {}) {
+  const target = getRuntimeTarget(platform, architecture);
+  const cachedRuntimeDirectory = path.join(cacheRoot, target.key);
+
+  if (!(await hasCurrentRuntime(cachedRuntimeDirectory, target))) {
+    const temporaryDirectory = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'cue-whisper-runtime-'));
+    const preparedDirectory = path.join(temporaryDirectory, 'prepared');
+    try {
+      if (target.kind === 'archive') {
+        await prepareArchiveTarget(target, temporaryDirectory, preparedDirectory);
+      } else {
+        await prepareMacTarget(target, temporaryDirectory, preparedDirectory);
+      }
+      await fs.promises.writeFile(path.join(preparedDirectory, RUNTIME_MANIFEST_FILENAME), JSON.stringify({
+        name: 'whisper.cpp',
+        version: WHISPER_CPP_VERSION,
+        target: target.key
+      }, null, 2));
+      await replaceManagedDirectory(preparedDirectory, cachedRuntimeDirectory, cacheRoot);
+    } finally {
+      const resolvedTemporaryDirectory = path.resolve(temporaryDirectory);
+      if (resolvedTemporaryDirectory.startsWith(path.resolve(os.tmpdir()) + path.sep)) {
+        await fs.promises.rm(resolvedTemporaryDirectory, { recursive: true, force: true });
+      }
+    }
+  }
+
+  if (outputDirectory) {
+    const outputParent = path.dirname(path.resolve(outputDirectory));
+    await replaceManagedDirectory(cachedRuntimeDirectory, outputDirectory, outputParent);
+  }
+  return outputDirectory || cachedRuntimeDirectory;
+}
+
+async function main() {
+  const outputDirectory = readArgument('output');
+  const runtimeDirectory = await prepareWhisperRuntime({
+    platform: readArgument('platform') || process.platform,
+    architecture: readArgument('arch') || process.arch,
+    outputDirectory: outputDirectory ? path.resolve(outputDirectory) : null
+  });
+  process.stdout.write(`Prepared whisper.cpp ${WHISPER_CPP_VERSION} runtime at ${runtimeDirectory}\n`);
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(error.stack || error.message);
+    process.exitCode = 1;
+  });
+}
+
+module.exports = {
+  prepareWhisperRuntime,
+  assertSafeManagedDirectory,
+  shouldCopyRuntimeEntry,
+  extractTarWithMaterializedLinks
+};

--- a/scripts/verify-whisper-runtime.js
+++ b/scripts/verify-whisper-runtime.js
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+
+const path = require('path');
+const { spawnSync } = require('child_process');
+const { locateWhisperRuntime } = require('../src/whisper-runtime');
+
+function buildRuntimeEnvironment(runtimeDirectory) {
+  const environment = { ...process.env };
+  if (process.platform === 'win32') {
+    environment.PATH = `${runtimeDirectory}${path.delimiter}${environment.PATH || ''}`;
+  } else if (process.platform === 'darwin') {
+    environment.DYLD_LIBRARY_PATH = `${runtimeDirectory}${path.delimiter}${environment.DYLD_LIBRARY_PATH || ''}`;
+  } else {
+    environment.LD_LIBRARY_PATH = `${runtimeDirectory}${path.delimiter}${environment.LD_LIBRARY_PATH || ''}`;
+  }
+  return environment;
+}
+
+const runtime = locateWhisperRuntime({
+  isPackaged: false,
+  resourcesPath: process.resourcesPath,
+  appPath: path.resolve(__dirname, '..'),
+  platform: process.platform,
+  architecture: process.arch,
+  environment: process.env
+});
+if (!runtime.available) throw new Error(runtime.message);
+
+const result = spawnSync(runtime.executablePath, ['--help'], {
+  cwd: runtime.runtimeDirectory,
+  env: buildRuntimeEnvironment(runtime.runtimeDirectory),
+  encoding: 'utf8',
+  windowsHide: true
+});
+if (result.error) throw result.error;
+const output = `${result.stdout || ''}\n${result.stderr || ''}`;
+if (result.status !== 0 || !output.includes('whisper-server') || !output.includes('--model')) {
+  throw new Error(`whisper-server smoke test failed (${result.status}).\n${output.slice(-1200)}`);
+}
+process.stdout.write(`Verified whisper.cpp ${runtime.version} runtime for ${runtime.target}.\n`);

--- a/src/local-whisper-transcriber.js
+++ b/src/local-whisper-transcriber.js
@@ -1,0 +1,120 @@
+const { UtteranceSegmenter } = require('./utterance-segmenter');
+const { WhisperServerSession } = require('./whisper-server-session');
+
+const CHANNELS = Object.freeze(['you', 'them']);
+const DEFAULT_DRAIN_TIMEOUT_MS = 15000;
+
+class LocalWhisperTranscriber {
+  /** Coordinate two audio channels through one sequential, persistent model session. */
+  constructor({
+    sessionOptions,
+    sessionFactory = (options) => new WhisperServerSession(options),
+    segmenterFactory = (options) => new UtteranceSegmenter(options),
+    drainTimeoutMs = DEFAULT_DRAIN_TIMEOUT_MS,
+    onTranscript = () => {},
+    onSpeechState = () => {},
+    onStatus = () => {},
+    onError = () => {}
+  }) {
+    this.session = sessionFactory({ ...sessionOptions, onState: onStatus });
+    this.segmenterFactory = segmenterFactory;
+    this.drainTimeoutMs = drainTimeoutMs;
+    this.onTranscript = onTranscript;
+    this.onSpeechState = onSpeechState;
+    this.onStatus = onStatus;
+    this.onError = onError;
+    this.segmenters = new Map();
+    this.queueTail = Promise.resolve();
+    this.pendingJobs = 0;
+    this.acceptingAudio = false;
+    this.discardPendingJobs = false;
+  }
+
+  async start() {
+    this.discardPendingJobs = false;
+    await this.session.start();
+    for (const channel of CHANNELS) {
+      const isRemoteAudio = channel === 'them';
+      this.segmenters.set(channel, this.segmenterFactory({
+        channel,
+        vadOptions: {
+          onsetThreshold: isRemoteAudio ? 200 : 220,
+          offsetThreshold: isRemoteAudio ? 120 : 130,
+          silenceFrames: isRemoteAudio ? 20 : 18
+        },
+        onSpeechState: (speechChannel, speaking, durationMs) => {
+          this.onSpeechState(speechChannel, speaking, durationMs);
+        },
+        onUtterance: (utteranceChannel, pcm) => this._enqueue(utteranceChannel, pcm)
+      }));
+    }
+    this.acceptingAudio = true;
+  }
+
+  push(channel, pcm) {
+    if (!this.acceptingAudio) return;
+    const segmenter = this.segmenters.get(channel);
+    if (!segmenter) throw new Error(`Unknown local Whisper channel: ${channel}`);
+    segmenter.push(pcm);
+  }
+
+  async stop() {
+    this.acceptingAudio = false;
+    for (const segmenter of this.segmenters.values()) segmenter.stop();
+
+    const drained = await this._drainQueue();
+    if (!drained) {
+      this.discardPendingJobs = true;
+      this.session.abortInferences();
+    }
+    await this.session.stop({ force: !drained });
+    this.segmenters.clear();
+    this.onStatus({ status: 'off', message: 'Local Whisper stopped.' });
+  }
+
+  forceStop() {
+    this.acceptingAudio = false;
+    this.discardPendingJobs = true;
+    this.session.abortInferences();
+    return this.session.stop({ force: true });
+  }
+
+  _enqueue(channel, pcm) {
+    this.pendingJobs += 1;
+    this.onStatus({ status: 'transcribing', channel, pending: this.pendingJobs });
+
+    const job = this.queueTail.then(async () => {
+      if (this.discardPendingJobs) return;
+      const text = await this.session.transcribe(pcm);
+      if (text) this.onTranscript(channel, text);
+    });
+
+    this.queueTail = job
+      .catch((error) => {
+        if (!this.discardPendingJobs) this.onError(error);
+      })
+      .finally(() => {
+        this.pendingJobs -= 1;
+        if (this.acceptingAudio && this.pendingJobs === 0) {
+          this.onStatus({ status: 'ready', message: 'Local Whisper is ready.' });
+        }
+      });
+    return job;
+  }
+
+  async _drainQueue() {
+    let timeout = null;
+    try {
+      return await Promise.race([
+        this.queueTail.then(() => true),
+        new Promise((resolve) => {
+          timeout = setTimeout(() => resolve(false), this.drainTimeoutMs);
+        })
+      ]);
+    } finally {
+      if (timeout) clearTimeout(timeout);
+    }
+  }
+}
+
+module.exports = { LocalWhisperTranscriber, CHANNELS, DEFAULT_DRAIN_TIMEOUT_MS };

--- a/src/store.js
+++ b/src/store.js
@@ -7,6 +7,12 @@ const FILE = path.join(app.getPath('userData'), 'cue-data.json');
 
 const DEFAULTS = {
   provider: 'openai',
+  sttProvider: 'auto',
+  localWhisper: {
+    modelId: 'base.en',
+    language: 'auto',
+    threads: 0
+  },
   smart: false,
   apiKeys: { openai: '', anthropic: '', gemini: '', deepgram: '' },
   // Tab 2: Profile

--- a/src/stt-streaming.js
+++ b/src/stt-streaming.js
@@ -382,10 +382,15 @@ async function transcribeBatchGemini(apiKey, wav) {
 
 function createStreamingSTT(settings, channel, callbacks) {
   const keys = settings.apiKeys || {};
+  const selectedProvider = settings.sttProvider || 'auto';
   const { onTranscript, onInterim, onError, onStatusChange } = callbacks;
 
+  if (selectedProvider === 'local' || selectedProvider === 'gemini') {
+    return { type: 'batch', provider: selectedProvider, instance: null };
+  }
+
   // Priority 1: Deepgram (purpose-built for streaming STT, lowest latency)
-  if (keys.deepgram) {
+  if ((selectedProvider === 'auto' || selectedProvider === 'deepgram') && keys.deepgram) {
     const stt = new DeepgramStreamingSTT(keys.deepgram, {
       model: 'nova-3',
       onTranscript: (text) => onTranscript(channel, text),
@@ -397,7 +402,7 @@ function createStreamingSTT(settings, channel, callbacks) {
   }
 
   // Priority 2: OpenAI Realtime API (excellent quality, slightly higher latency)
-  if (keys.openai) {
+  if ((selectedProvider === 'auto' || selectedProvider === 'openai') && keys.openai) {
     const stt = new OpenAIRealtimeSTT(keys.openai, {
       model: 'gpt-realtime-whisper', // only this model gives true streaming deltas
       onTranscript: (text) => onTranscript(channel, text),
@@ -409,7 +414,11 @@ function createStreamingSTT(settings, channel, callbacks) {
   }
 
   // Priority 3: Batch fallback (Gemini or Whisper via old system)
-  return { type: 'batch', provider: keys.gemini ? 'gemini' : 'none', instance: null };
+  return {
+    type: 'batch',
+    provider: selectedProvider === 'auto' && keys.gemini ? 'gemini' : 'none',
+    instance: null
+  };
 }
 
 module.exports = {

--- a/src/stt.js
+++ b/src/stt.js
@@ -27,9 +27,14 @@ async function transcribeGemini(apiKey, wav) {
 
 function createSTT(settings) {
   const keys = settings.apiKeys || {};
+  const selectedProvider = settings.sttProvider || 'auto';
   const chain = [];
-  if (keys.openai) chain.push({ p: 'openai', fn: (wav) => transcribeOpenAI(keys.openai, wav, settings.sttModel) });
-  if (keys.gemini) chain.push({ p: 'gemini', fn: (wav) => transcribeGemini(keys.gemini, wav) });
+  if ((selectedProvider === 'auto' || selectedProvider === 'openai') && keys.openai) {
+    chain.push({ p: 'openai', fn: (wav) => transcribeOpenAI(keys.openai, wav, settings.sttModel) });
+  }
+  if ((selectedProvider === 'auto' || selectedProvider === 'gemini') && keys.gemini) {
+    chain.push({ p: 'gemini', fn: (wav) => transcribeGemini(keys.gemini, wav) });
+  }
   if (keys.openai && chain.length > 1) chain.unshift(chain.splice(chain.findIndex((c) => c.p === 'openai'), 1)[0]);
 
   let disabledUntil = 0;

--- a/src/utterance-segmenter.js
+++ b/src/utterance-segmenter.js
@@ -1,0 +1,137 @@
+const { AdaptiveVAD, AudioRingBuffer } = require('./vad');
+
+const DEFAULT_SAMPLE_RATE = 16000;
+const PCM_BYTES_PER_SAMPLE = 2;
+const DEFAULT_PRE_ROLL_MS = 300;
+const DEFAULT_MIN_UTTERANCE_MS = 180;
+const DEFAULT_MAX_UTTERANCE_MS = 25000;
+const DEFAULT_OVERLAP_MS = 300;
+
+class UtteranceSegmenter {
+  /** Segment one PCM channel into bounded utterances without writing audio to disk. */
+  constructor({
+    channel,
+    sampleRate = DEFAULT_SAMPLE_RATE,
+    preRollMs = DEFAULT_PRE_ROLL_MS,
+    minUtteranceMs = DEFAULT_MIN_UTTERANCE_MS,
+    maxUtteranceMs = DEFAULT_MAX_UTTERANCE_MS,
+    overlapMs = DEFAULT_OVERLAP_MS,
+    vadOptions = {},
+    onSpeechState = () => {},
+    onUtterance = () => {}
+  }) {
+    if (!channel) throw new Error('UtteranceSegmenter requires a channel.');
+    this.channel = channel;
+    this.sampleRate = sampleRate;
+    this.minimumBytes = this._millisecondsToBytes(minUtteranceMs);
+    this.maximumBytes = this._millisecondsToBytes(maxUtteranceMs);
+    this.overlapBytes = this._millisecondsToBytes(overlapMs);
+    this.onSpeechState = onSpeechState;
+    this.onUtterance = onUtterance;
+    this.ringBuffer = new AudioRingBuffer(preRollMs, sampleRate);
+    this.utteranceChunks = [];
+    this.utteranceBytes = 0;
+    this.collecting = false;
+    this.startedDuringPush = false;
+    this.endedDuringPush = false;
+
+    this.vad = new AdaptiveVAD({
+      sampleRate,
+      ...vadOptions,
+      onSpeechStart: () => this._beginUtterance(),
+      onSpeechEnd: (durationMs) => this._requestUtteranceEnd(durationMs)
+    });
+  }
+
+  push(pcm) {
+    const chunk = Buffer.from(pcm || []);
+    if (chunk.length < PCM_BYTES_PER_SAMPLE) return;
+    if (chunk.length % PCM_BYTES_PER_SAMPLE !== 0) {
+      throw new Error('PCM chunks must contain complete 16-bit samples.');
+    }
+
+    this.startedDuringPush = false;
+    this.endedDuringPush = false;
+    const wasCollecting = this.collecting;
+
+    if (!wasCollecting) this.ringBuffer.write(chunk);
+    this.vad.processChunk(chunk);
+
+    // A chunk that triggered speech start is already present in the pre-roll.
+    if (wasCollecting) this._appendChunk(chunk);
+    if (this.endedDuringPush) this._finalizeUtterance();
+  }
+
+  stop() {
+    if (this.collecting) this._finalizeUtterance();
+    this.reset();
+  }
+
+  reset() {
+    this.collecting = false;
+    this.startedDuringPush = false;
+    this.endedDuringPush = false;
+    this.utteranceChunks = [];
+    this.utteranceBytes = 0;
+    this.ringBuffer.clear();
+    this.vad.reset();
+  }
+
+  _beginUtterance() {
+    this.collecting = true;
+    this.startedDuringPush = true;
+    const preRoll = this.ringBuffer.read();
+    this.utteranceChunks = preRoll.length ? [Buffer.from(preRoll)] : [];
+    this.utteranceBytes = preRoll.length;
+    this.ringBuffer.clear();
+    this.onSpeechState(this.channel, true);
+  }
+
+  _requestUtteranceEnd(durationMs) {
+    this.endedDuringPush = true;
+    this.onSpeechState(this.channel, false, durationMs);
+  }
+
+  // Time O(n), space O(n) at each 25-second boundary; regular pushes are O(1).
+  _appendChunk(chunk) {
+    this.utteranceChunks.push(chunk);
+    this.utteranceBytes += chunk.length;
+
+    while (this.utteranceBytes >= this.maximumBytes) {
+      const combined = Buffer.concat(this.utteranceChunks, this.utteranceBytes);
+      this._emit(combined.subarray(0, this.maximumBytes));
+      const nextStart = Math.max(0, this.maximumBytes - this.overlapBytes);
+      const remainder = Buffer.from(combined.subarray(nextStart));
+      this.utteranceChunks = remainder.length ? [remainder] : [];
+      this.utteranceBytes = remainder.length;
+    }
+  }
+
+  _finalizeUtterance() {
+    if (!this.collecting) return;
+    const utterance = Buffer.concat(this.utteranceChunks, this.utteranceBytes);
+    if (utterance.length >= this.minimumBytes) this._emit(utterance);
+    this.collecting = false;
+    this.endedDuringPush = false;
+    this.utteranceChunks = [];
+    this.utteranceBytes = 0;
+    this.ringBuffer.clear();
+  }
+
+  _emit(pcm) {
+    this.onUtterance(this.channel, Buffer.from(pcm));
+  }
+
+  _millisecondsToBytes(durationMs) {
+    return Math.floor(this.sampleRate * PCM_BYTES_PER_SAMPLE * durationMs / 1000);
+  }
+}
+
+module.exports = {
+  UtteranceSegmenter,
+  DEFAULT_SAMPLE_RATE,
+  DEFAULT_PRE_ROLL_MS,
+  DEFAULT_MIN_UTTERANCE_MS,
+  DEFAULT_MAX_UTTERANCE_MS,
+  DEFAULT_OVERLAP_MS
+};

--- a/src/whisper-model-catalog.js
+++ b/src/whisper-model-catalog.js
@@ -1,0 +1,98 @@
+const DEFAULT_MODEL_ID = 'base.en';
+const STANDARD_MODEL_REPOSITORY = 'ggerganov/whisper.cpp';
+const TINYDIARIZE_MODEL_REPOSITORY = 'akashmjn/tinydiarize-whisper.cpp';
+
+/**
+ * Models published by whisper.cpp's official download script. Hashes and byte
+ * counts come from each repository's Git LFS metadata and are intentionally
+ * pinned so a corrupted or replaced download cannot be loaded.
+ */
+const MODEL_ARTIFACTS = Object.freeze([
+  ['tiny', 77691713, 'be07e048e1e599ad46341c8d2a135645097a538221678b7acdd1b1919c6e1b21'],
+  ['tiny.en', 77704715, '921e4cf8686fdd993dcd081a5da5b6c365bfde1162e72b08d75ac75289920b1f'],
+  ['tiny-q5_1', 32152673, '818710568da3ca15689e31a743197b520007872ff9576237bda97bd1b469c3d7'],
+  ['tiny.en-q5_1', 32166155, 'c77c5766f1cef09b6b7d47f21b546cbddd4157886b3b5d6d4f709e91e66c7c2b'],
+  ['tiny-q8_0', 43537433, 'c2085835d3f50733e2ff6e4b41ae8a2b8d8110461e18821b09a15c40c42d1cca'],
+  ['base', 147951465, '60ed5bc3dd14eea856493d334349b405782ddcaf0028d4b5df4088345fba2efe'],
+  ['base.en', 147964211, 'a03779c86df3323075f5e796cb2ce5029f00ec8869eee3fdfb897afe36c6d002'],
+  ['base-q5_1', 59707625, '422f1ae452ade6f30a004d7e5c6a43195e4433bc370bf23fac9cc591f01a8898'],
+  ['base.en-q5_1', 59721011, '4baf70dd0d7c4247ba2b81fafd9c01005ac77c2f9ef064e00dcf195d0e2fdd2f'],
+  ['base-q8_0', 81768585, 'c577b9a86e7e048a0b7eada054f4dd79a56bbfa911fbdacf900ac5b567cbb7d9'],
+  ['small', 487601967, '1be3a9b2063867b937e64e2ec7483364a79917e157fa98c5d94b5c1fffea987b'],
+  ['small.en', 487614201, 'c6138d6d58ecc8322097e0f987c32f1be8bb0a18532a3f88f734d1bbf9c41e5d'],
+  ['small.en-tdrz', 487614184, 'ceac3ec06d1d98ef71aec665283564631055fd6129b79d8e1be4f9cc33cc54b4'],
+  ['small-q5_1', 190085487, 'ae85e4a935d7a567bd102fe55afc16bb595bdb618e11b2fc7591bc08120411bb'],
+  ['small.en-q5_1', 190098681, 'bfdff4894dcb76bbf647d56263ea2a96645423f1669176f4844a1bf8e478ad30'],
+  ['small-q8_0', 264464607, '49c8fb02b65e6049d5fa6c04f81f53b867b5ec9540406812c643f177317f779f'],
+  ['medium', 1533763059, '6c14d5adee5f86394037b4e4e8b59f1673b6cee10e3cf0b11bbdbee79c156208'],
+  ['medium.en', 1533774781, 'cc37e93478338ec7700281a7ac30a10128929eb8f427dda2e865faa8f6da4356'],
+  ['medium-q5_0', 539212467, '19fea4b380c3a618ec4723c3eef2eb785ffba0d0538cf43f8f235e7b3b34220f'],
+  ['medium.en-q5_0', 539225533, '76733e26ad8fe1c7a5bf7531a9d41917b2adc0f20f2e4f5531688a8c6cd88eb0'],
+  ['medium-q8_0', 823369779, '42a1ffcbe4167d224232443396968db4d02d4e8e87e213d3ee2e03095dea6502'],
+  ['large-v1', 3094623691, '7d99f41a10525d0206bddadd86760181fa920438b6b33237e3118ff6c83bb53d'],
+  ['large-v2', 3094623691, '9a423fe4d40c82774b6af34115b8b935f34152246eb19e80e376071d3f999487'],
+  ['large-v2-q5_0', 1080732091, '3a214837221e4530dbc1fe8d734f302af393eb30bd0ed046042ebf4baf70f6f2'],
+  ['large-v2-q8_0', 1656129691, 'fef54e6d898246a65c8285bfa83bd1807e27fadf54d5d4e81754c47634737e8c'],
+  ['large-v3', 3095033483, '64d182b440b98d5203c4f9bd541544d84c605196c4f7b845dfa11fb23594d1e2'],
+  ['large-v3-q5_0', 1081140203, 'd75795ecff3f83b5faa89d1900604ad8c780abd5739fae406de19f23ecd98ad1'],
+  ['large-v3-turbo', 1624555275, '1fc70f774d38eb169993ac391eea357ef47c88757ef72ee5943879b7e8e2bc69'],
+  ['large-v3-turbo-q5_0', 574041195, '394221709cd5ad1f40c46e6031ca61bce88931e6e088c188294c6d5a55ffa7e2'],
+  ['large-v3-turbo-q8_0', 874188075, '317eb69c11673c9de1e1f0d459b253999804ec71ac4c23c17ecf5fbe24e259a1']
+]);
+
+function getFamily(modelId) {
+  if (modelId.startsWith('large-v3-turbo')) return 'large-v3-turbo';
+  if (modelId.startsWith('large')) return 'large';
+  return modelId.split(/[.-]/)[0];
+}
+
+function getQuantization(modelId) {
+  const match = modelId.match(/-(q\d+_\d+)$/);
+  return match ? match[1].toUpperCase() : 'Full precision';
+}
+
+function getHardwareTier(family) {
+  if (family === 'tiny') return 'Lightest';
+  if (family === 'base') return 'Light';
+  if (family === 'small') return 'Balanced';
+  if (family === 'medium') return 'Heavy';
+  return 'Very heavy';
+}
+
+function buildArtifact([id, bytes, sha256]) {
+  const repository = id === 'small.en-tdrz'
+    ? TINYDIARIZE_MODEL_REPOSITORY
+    : STANDARD_MODEL_REPOSITORY;
+  const filename = `ggml-${id}.bin`;
+  const family = getFamily(id);
+
+  return Object.freeze({
+    id,
+    label: id,
+    filename,
+    bytes,
+    sha256,
+    url: `https://huggingface.co/${repository}/resolve/main/${filename}`,
+    englishOnly: id.includes('.en'),
+    tinydiarize: id.endsWith('-tdrz'),
+    quantization: getQuantization(id),
+    hardwareTier: getHardwareTier(family),
+    recommended: id === DEFAULT_MODEL_ID
+  });
+}
+
+const WHISPER_MODELS = Object.freeze(MODEL_ARTIFACTS.map(buildArtifact));
+const MODEL_BY_ID = new Map(WHISPER_MODELS.map((model) => [model.id, model]));
+
+/** Return a trusted model descriptor or fail before touching the filesystem. */
+function requireWhisperModel(modelId) {
+  const model = MODEL_BY_ID.get(modelId);
+  if (!model) throw new Error(`Unsupported Whisper model: ${modelId}`);
+  return model;
+}
+
+module.exports = {
+  DEFAULT_MODEL_ID,
+  WHISPER_MODELS,
+  requireWhisperModel
+};

--- a/src/whisper-model-manager.js
+++ b/src/whisper-model-manager.js
@@ -1,0 +1,248 @@
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+const { once } = require('events');
+const { finished } = require('stream/promises');
+const { WHISPER_MODELS } = require('./whisper-model-catalog');
+
+const MODEL_DIRECTORY_NAME = 'whisper-models';
+const PROGRESS_INTERVAL_MS = 150;
+
+class WhisperModelManager {
+  /**
+   * Manage verified model artifacts under Electron's userData directory.
+   * Dependencies are injectable so downloads can be tested without a network.
+   */
+  constructor({ userDataPath, fetchImpl = global.fetch, now = Date.now, models = WHISPER_MODELS } = {}) {
+    if (!userDataPath) throw new Error('WhisperModelManager requires a userDataPath.');
+    if (typeof fetchImpl !== 'function') throw new Error('A Fetch-compatible implementation is required.');
+
+    this.modelDirectory = path.join(userDataPath, MODEL_DIRECTORY_NAME);
+    this.fetchImpl = fetchImpl;
+    this.now = now;
+    this.models = Object.freeze(Array.from(models));
+    this.modelById = new Map(this.models.map((model) => [model.id, model]));
+    this.activeDownload = null;
+  }
+
+  getModelPath(modelId) {
+    return path.join(this.modelDirectory, this._requireModel(modelId).filename);
+  }
+
+  getPartialPath(modelId) {
+    return `${this.getModelPath(modelId)}.part`;
+  }
+
+  async listModels() {
+    await fs.promises.mkdir(this.modelDirectory, { recursive: true });
+    return Promise.all(this.models.map(async (model) => {
+      const [installedBytes, partialBytes] = await Promise.all([
+        this._getFileSize(this.getModelPath(model.id)),
+        this._getFileSize(this.getPartialPath(model.id))
+      ]);
+      return {
+        ...model,
+        installed: installedBytes === model.bytes,
+        installedBytes,
+        partialBytes,
+        downloading: this.activeDownload?.modelId === model.id
+      };
+    }));
+  }
+
+  /**
+   * Download one model at a time. A valid partial file is resumed with Range;
+   * completed bytes remain on cancellation so the next attempt can continue.
+   */
+  async download(modelId, onProgress = () => {}) {
+    const model = this._requireModel(modelId);
+    if (this.activeDownload) {
+      throw new Error(`Already downloading ${this.activeDownload.modelId}.`);
+    }
+
+    await fs.promises.mkdir(this.modelDirectory, { recursive: true });
+    const targetPath = this.getModelPath(modelId);
+    const partialPath = this.getPartialPath(modelId);
+    const targetBytes = await this._getFileSize(targetPath);
+    if (targetBytes === model.bytes) {
+      try {
+        await this._verifyArtifact(targetPath, model);
+        return { modelId, installed: true, resumed: false };
+      } catch {
+        await fs.promises.rm(targetPath, { force: true });
+      }
+    } else {
+      await fs.promises.rm(targetPath, { force: true });
+    }
+
+    let partialBytes = await this._getFileSize(partialPath);
+    if (partialBytes > model.bytes) {
+      await fs.promises.truncate(partialPath, 0);
+      partialBytes = 0;
+    }
+    if (partialBytes === model.bytes) {
+      try {
+        await this._verifyArtifact(partialPath, model);
+        await fs.promises.rename(partialPath, targetPath);
+        return { modelId, installed: true, resumed: true };
+      } catch {
+        await fs.promises.truncate(partialPath, 0);
+        partialBytes = 0;
+      }
+    }
+
+    const abortController = new AbortController();
+    this.activeDownload = { modelId, abortController };
+    const headers = partialBytes > 0 ? { Range: `bytes=${partialBytes}-` } : {};
+
+    try {
+      const response = await this.fetchImpl(model.url, {
+        headers,
+        redirect: 'follow',
+        signal: abortController.signal
+      });
+      const shouldAppend = partialBytes > 0 && response.status === 206;
+      if (!response.ok) {
+        throw new Error(`Model download failed with HTTP ${response.status}.`);
+      }
+
+      if (!shouldAppend) partialBytes = 0;
+      await this._writeResponseBody(response, partialPath, model, partialBytes, shouldAppend, onProgress);
+      await this._verifyArtifact(partialPath, model);
+      await fs.promises.rename(partialPath, targetPath);
+      onProgress({ modelId, receivedBytes: model.bytes, totalBytes: model.bytes, percent: 100 });
+      return { modelId, installed: true, resumed: shouldAppend };
+    } catch (error) {
+      if (abortController.signal.aborted) {
+        const cancelledError = new Error(`Download cancelled for ${modelId}.`);
+        cancelledError.code = 'DOWNLOAD_CANCELLED';
+        throw cancelledError;
+      }
+      if (error.code === 'ARTIFACT_CHECKSUM_MISMATCH' || error.code === 'ARTIFACT_SIZE_MISMATCH') {
+        await fs.promises.rm(partialPath, { force: true });
+      }
+      throw error;
+    } finally {
+      this.activeDownload = null;
+    }
+  }
+
+  cancelDownload(modelId) {
+    if (!this.activeDownload || this.activeDownload.modelId !== modelId) return false;
+    this.activeDownload.abortController.abort();
+    return true;
+  }
+
+  async deleteModel(modelId) {
+    this._requireModel(modelId);
+    if (this.activeDownload?.modelId === modelId) {
+      throw new Error('Cancel the active download before deleting this model.');
+    }
+    await Promise.all([
+      fs.promises.rm(this.getModelPath(modelId), { force: true }),
+      fs.promises.rm(this.getPartialPath(modelId), { force: true })
+    ]);
+    return { modelId, installed: false };
+  }
+
+  async importModel(modelId, sourcePath) {
+    const model = this._requireModel(modelId);
+    if (!sourcePath) throw new Error('No model file was selected.');
+    if (this.activeDownload) throw new Error('Wait for the active model download to finish.');
+
+    await fs.promises.mkdir(this.modelDirectory, { recursive: true });
+    const targetPath = this.getModelPath(modelId);
+    const importingPath = `${targetPath}.importing`;
+    await fs.promises.copyFile(sourcePath, importingPath);
+    try {
+      await this._verifyArtifact(importingPath, model);
+      await fs.promises.rm(targetPath, { force: true });
+      await fs.promises.rename(importingPath, targetPath);
+      return { modelId, installed: true };
+    } catch (error) {
+      await fs.promises.rm(importingPath, { force: true });
+      throw error;
+    }
+  }
+
+  async verifyInstalledModel(modelId) {
+    const model = this._requireModel(modelId);
+    const modelPath = this.getModelPath(modelId);
+    await fs.promises.access(modelPath, fs.constants.R_OK);
+    await this._verifyArtifact(modelPath, model);
+    return modelPath;
+  }
+
+  // Time O(n), space O(1): audio models can be several GB, so hash by stream.
+  async _sha256(filePath) {
+    const hash = crypto.createHash('sha256');
+    const input = fs.createReadStream(filePath);
+    for await (const chunk of input) hash.update(chunk);
+    return hash.digest('hex');
+  }
+
+  async _verifyArtifact(filePath, model) {
+    const bytes = await this._getFileSize(filePath);
+    if (bytes !== model.bytes) {
+      const error = new Error(`Model size mismatch for ${model.id}: expected ${model.bytes}, received ${bytes}.`);
+      error.code = 'ARTIFACT_SIZE_MISMATCH';
+      throw error;
+    }
+    const sha256 = await this._sha256(filePath);
+    if (sha256 !== model.sha256) {
+      const error = new Error(`Model checksum mismatch for ${model.id}.`);
+      error.code = 'ARTIFACT_CHECKSUM_MISMATCH';
+      throw error;
+    }
+  }
+
+  async _getFileSize(filePath) {
+    try {
+      return (await fs.promises.stat(filePath)).size;
+    } catch (error) {
+      if (error.code === 'ENOENT') return 0;
+      throw error;
+    }
+  }
+
+  _requireModel(modelId) {
+    const model = this.modelById.get(modelId);
+    if (!model) throw new Error(`Unsupported Whisper model: ${modelId}`);
+    return model;
+  }
+
+  async _writeResponseBody(response, partialPath, model, startingBytes, append, onProgress) {
+    if (!response.body) throw new Error('Model download returned an empty body.');
+    const output = fs.createWriteStream(partialPath, { flags: append ? 'a' : 'w' });
+    const outputFinished = finished(output);
+    let receivedBytes = startingBytes;
+    let lastProgressAt = 0;
+
+    try {
+      for await (const chunk of response.body) {
+        const buffer = Buffer.from(chunk);
+        receivedBytes += buffer.length;
+        if (receivedBytes > model.bytes) {
+          throw new Error(`Model download exceeded the expected size for ${model.id}.`);
+        }
+        if (!output.write(buffer)) await once(output, 'drain');
+
+        const progressTime = this.now();
+        if (progressTime - lastProgressAt >= PROGRESS_INTERVAL_MS) {
+          lastProgressAt = progressTime;
+          onProgress({
+            modelId: model.id,
+            receivedBytes,
+            totalBytes: model.bytes,
+            percent: Math.floor((receivedBytes / model.bytes) * 100)
+          });
+        }
+      }
+    } finally {
+      output.end();
+      await outputFinished;
+    }
+  }
+}
+
+module.exports = { WhisperModelManager, MODEL_DIRECTORY_NAME };

--- a/src/whisper-runtime-manifest.js
+++ b/src/whisper-runtime-manifest.js
@@ -1,0 +1,67 @@
+const path = require('path');
+
+const WHISPER_CPP_VERSION = '1.9.1';
+const RELEASE_BASE_URL = `https://github.com/ggml-org/whisper.cpp/releases/download/v${WHISPER_CPP_VERSION}`;
+const SOURCE_ARCHIVE_URL = `https://github.com/ggml-org/whisper.cpp/archive/refs/tags/v${WHISPER_CPP_VERSION}.zip`;
+const SOURCE_ARCHIVE_SHA256 = 'e684d836a67616c0d51c9239245a46ee6a7203258b2b3354e456af5039482d13';
+
+const RUNTIME_TARGETS = Object.freeze({
+  'win32-x64': Object.freeze({
+    kind: 'archive',
+    archiveType: 'zip',
+    filename: 'whisper-bin-x64.zip',
+    bytes: 7982101,
+    sha256: '7d8be46ecd31828e1eb7a2ecdd0d6b314feafd82163038ab6092594b0a063539',
+    executable: 'whisper-server.exe'
+  }),
+  'linux-x64': Object.freeze({
+    kind: 'archive',
+    archiveType: 'tar.gz',
+    filename: 'whisper-bin-ubuntu-x64.tar.gz',
+    bytes: 9379235,
+    sha256: 'f3bf3b4369a99b54665b0f19b88483b30de27f25963b0414235dea03198515c5',
+    executable: 'whisper-server'
+  }),
+  'linux-arm64': Object.freeze({
+    kind: 'archive',
+    archiveType: 'tar.gz',
+    filename: 'whisper-bin-ubuntu-arm64.tar.gz',
+    bytes: 4555819,
+    sha256: 'e0b66cd551ff6f2a28fabe3c6e89691eea037bb76833493abb9a71ca788994b3',
+    executable: 'whisper-server'
+  }),
+  'darwin-x64': Object.freeze({
+    kind: 'source',
+    sourceArchitecture: 'x86_64',
+    executable: 'whisper-server'
+  }),
+  'darwin-arm64': Object.freeze({
+    kind: 'source',
+    sourceArchitecture: 'arm64',
+    executable: 'whisper-server'
+  })
+});
+
+function getRuntimeTarget(platform = process.platform, architecture = process.arch) {
+  const key = `${platform}-${architecture}`;
+  const target = RUNTIME_TARGETS[key];
+  if (!target) throw new Error(`Local Whisper is not packaged for ${key}.`);
+  return {
+    ...target,
+    key,
+    url: target.kind === 'archive' ? `${RELEASE_BASE_URL}/${target.filename}` : SOURCE_ARCHIVE_URL
+  };
+}
+
+function getRuntimeExecutablePath(runtimeDirectory, platform = process.platform, architecture = process.arch) {
+  return path.join(runtimeDirectory, getRuntimeTarget(platform, architecture).executable);
+}
+
+module.exports = {
+  WHISPER_CPP_VERSION,
+  RUNTIME_TARGETS,
+  SOURCE_ARCHIVE_URL,
+  SOURCE_ARCHIVE_SHA256,
+  getRuntimeTarget,
+  getRuntimeExecutablePath
+};

--- a/src/whisper-runtime.js
+++ b/src/whisper-runtime.js
@@ -1,0 +1,52 @@
+const fs = require('fs');
+const path = require('path');
+const { getRuntimeExecutablePath, getRuntimeTarget, WHISPER_CPP_VERSION } = require('./whisper-runtime-manifest');
+
+/** Locate only prepackaged or explicitly prepared runtimes; never fetch code. */
+function locateWhisperRuntime({
+  isPackaged,
+  resourcesPath,
+  appPath,
+  platform = process.platform,
+  architecture = process.arch,
+  environment = process.env
+}) {
+  const target = getRuntimeTarget(platform, architecture);
+  const candidates = [];
+
+  if (environment.CUE_WHISPER_RUNTIME) {
+    candidates.push(path.resolve(environment.CUE_WHISPER_RUNTIME));
+  }
+  if (isPackaged && resourcesPath) {
+    candidates.push(path.join(resourcesPath, 'whisper-runtime'));
+  }
+  if (!isPackaged && appPath) {
+    candidates.push(path.join(appPath, '.cache', 'whisper-runtime', target.key));
+  }
+
+  for (const runtimeDirectory of candidates) {
+    const executablePath = getRuntimeExecutablePath(runtimeDirectory, platform, architecture);
+    if (fs.existsSync(executablePath)) {
+      return {
+        available: true,
+        version: WHISPER_CPP_VERSION,
+        target: target.key,
+        runtimeDirectory,
+        executablePath
+      };
+    }
+  }
+
+  return {
+    available: false,
+    version: WHISPER_CPP_VERSION,
+    target: target.key,
+    runtimeDirectory: candidates[0] || null,
+    executablePath: null,
+    message: isPackaged
+      ? `The packaged Whisper runtime for ${target.key} is missing.`
+      : 'Run npm run prepare:whisper before using local transcription from source.'
+  };
+}
+
+module.exports = { locateWhisperRuntime };

--- a/src/whisper-server-session.js
+++ b/src/whisper-server-session.js
@@ -1,0 +1,253 @@
+const crypto = require('crypto');
+const fs = require('fs');
+const net = require('net');
+const path = require('path');
+const { spawn } = require('child_process');
+const { pcmToWav } = require('./wav');
+
+const LOOPBACK_HOST = '127.0.0.1';
+const STARTUP_TIMEOUT_MS = 180000;
+const HEALTH_POLL_MS = 150;
+const INFERENCE_TIMEOUT_MS = 120000;
+const PROCESS_EXIT_TIMEOUT_MS = 3000;
+const MAX_LOG_TAIL_CHARACTERS = 12000;
+
+function delay(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+async function findFreeLoopbackPort() {
+  const server = net.createServer();
+  await new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, LOOPBACK_HOST, resolve);
+  });
+  const address = server.address();
+  await new Promise((resolve) => server.close(resolve));
+  if (!address || typeof address === 'string') throw new Error('Could not allocate a local Whisper port.');
+  return address.port;
+}
+
+function buildMultipartBody(wav) {
+  const boundary = `cue-${crypto.randomBytes(16).toString('hex')}`;
+  const fields = [
+    `--${boundary}\r\nContent-Disposition: form-data; name="response_format"\r\n\r\njson\r\n`,
+    `--${boundary}\r\nContent-Disposition: form-data; name="temperature"\r\n\r\n0.0\r\n`,
+    `--${boundary}\r\nContent-Disposition: form-data; name="file"; filename="audio.wav"\r\nContent-Type: audio/wav\r\n\r\n`
+  ];
+  return {
+    boundary,
+    body: Buffer.concat([
+      Buffer.from(fields.join(''), 'utf8'),
+      wav,
+      Buffer.from(`\r\n--${boundary}--\r\n`, 'utf8')
+    ])
+  };
+}
+
+class WhisperServerSession {
+  /** Supervise one model-loaded whisper-server process for an entire capture session. */
+  constructor({
+    executablePath,
+    runtimeDirectory,
+    modelPath,
+    language = 'auto',
+    threads = 0,
+    tinydiarize = false,
+    fetchImpl = global.fetch,
+    spawnImpl = spawn,
+    findPort = findFreeLoopbackPort,
+    wait = delay,
+    randomBytes = crypto.randomBytes,
+    onState = () => {}
+  }) {
+    if (!executablePath || !runtimeDirectory || !modelPath) {
+      throw new Error('WhisperServerSession requires runtime and model paths.');
+    }
+    if (typeof fetchImpl !== 'function') throw new Error('A Fetch-compatible implementation is required.');
+
+    this.executablePath = executablePath;
+    this.runtimeDirectory = runtimeDirectory;
+    this.modelPath = modelPath;
+    this.language = language;
+    this.threads = Number.isInteger(threads) && threads > 0 ? threads : 0;
+    this.tinydiarize = tinydiarize;
+    this.fetchImpl = fetchImpl;
+    this.spawnImpl = spawnImpl;
+    this.findPort = findPort;
+    this.wait = wait;
+    this.randomBytes = randomBytes;
+    this.onState = onState;
+    this.child = null;
+    this.endpoint = null;
+    this.healthEndpoint = null;
+    this.logTail = '';
+    this.exitError = null;
+    this.stopRequested = false;
+    this.inferenceControllers = new Set();
+  }
+
+  async start() {
+    if (this.child) return;
+    this.stopRequested = false;
+    this.exitError = null;
+    this.logTail = '';
+    await Promise.all([
+      fs.promises.access(this.executablePath, fs.constants.X_OK),
+      fs.promises.access(this.modelPath, fs.constants.R_OK)
+    ]);
+
+    const port = await this.findPort();
+    const requestPath = `/cue-${this.randomBytes(24).toString('hex')}`;
+    this.endpoint = `http://${LOOPBACK_HOST}:${port}${requestPath}/inference`;
+    this.healthEndpoint = `http://${LOOPBACK_HOST}:${port}${requestPath}/health`;
+    const argumentsList = this._buildArguments(port, requestPath);
+
+    this.onState({ status: 'loading', message: 'Loading the local Whisper model…' });
+    this.child = this.spawnImpl(this.executablePath, argumentsList, {
+      cwd: this.runtimeDirectory,
+      env: this._buildRuntimeEnvironment(),
+      stdio: ['ignore', 'pipe', 'pipe'],
+      windowsHide: true
+    });
+    this._observeChild(this.child);
+
+    try {
+      await this._waitUntilHealthy();
+      this.onState({ status: 'ready', message: 'Local Whisper is ready.' });
+    } catch (error) {
+      await this.stop({ force: true });
+      throw error;
+    }
+  }
+
+  async transcribe(pcm) {
+    if (!this.child || !this.endpoint) throw new Error('Local Whisper is not running.');
+    const wav = pcmToWav(Buffer.from(pcm), 16000, 1);
+    const multipart = buildMultipartBody(wav);
+    const abortController = new AbortController();
+    const timeout = setTimeout(() => abortController.abort(), INFERENCE_TIMEOUT_MS);
+    this.inferenceControllers.add(abortController);
+
+    try {
+      const response = await this.fetchImpl(this.endpoint, {
+        method: 'POST',
+        headers: {
+          'Content-Type': `multipart/form-data; boundary=${multipart.boundary}`,
+          'Content-Length': String(multipart.body.length)
+        },
+        body: multipart.body,
+        signal: abortController.signal
+      });
+      const responseText = await response.text();
+      if (!response.ok) {
+        throw new Error(`Local Whisper returned HTTP ${response.status}: ${responseText.slice(0, 300)}`);
+      }
+      const parsed = JSON.parse(responseText);
+      return String(parsed.text || '').trim();
+    } catch (error) {
+      if (abortController.signal.aborted) throw new Error('Local Whisper inference timed out.');
+      throw error;
+    } finally {
+      clearTimeout(timeout);
+      this.inferenceControllers.delete(abortController);
+    }
+  }
+
+  abortInferences() {
+    for (const controller of this.inferenceControllers) controller.abort();
+  }
+
+  async stop({ force = false } = {}) {
+    this.stopRequested = true;
+    const child = this.child;
+    this.child = null;
+    this.endpoint = null;
+    this.healthEndpoint = null;
+    if (!child) return;
+
+    this.abortInferences();
+    if (child.exitCode !== null || child.signalCode !== null) return;
+    const exited = new Promise((resolve) => child.once('exit', resolve));
+    child.kill(force ? 'SIGKILL' : 'SIGTERM');
+    if (force) return;
+
+    let exitTimeout = null;
+    const closedGracefully = await Promise.race([
+      exited.then(() => true),
+      new Promise((resolve) => {
+        exitTimeout = setTimeout(() => resolve(false), PROCESS_EXIT_TIMEOUT_MS);
+      })
+    ]);
+    if (exitTimeout) clearTimeout(exitTimeout);
+    if (!closedGracefully && child.exitCode === null) child.kill('SIGKILL');
+  }
+
+  _buildArguments(port, requestPath) {
+    const argumentsList = [
+      '--model', this.modelPath,
+      '--host', LOOPBACK_HOST,
+      '--port', String(port),
+      '--request-path', requestPath,
+      '--language', this.language,
+      '--no-timestamps',
+      '--suppress-nst'
+    ];
+    if (this.threads > 0) argumentsList.push('--threads', String(this.threads));
+    if (this.tinydiarize) argumentsList.push('--tinydiarize');
+    return argumentsList;
+  }
+
+  _buildRuntimeEnvironment() {
+    const environment = { ...process.env };
+    if (process.platform === 'win32') {
+      environment.PATH = `${this.runtimeDirectory}${path.delimiter}${environment.PATH || ''}`;
+    } else if (process.platform === 'darwin') {
+      environment.DYLD_LIBRARY_PATH = `${this.runtimeDirectory}${path.delimiter}${environment.DYLD_LIBRARY_PATH || ''}`;
+    } else {
+      environment.LD_LIBRARY_PATH = `${this.runtimeDirectory}${path.delimiter}${environment.LD_LIBRARY_PATH || ''}`;
+    }
+    return environment;
+  }
+
+  _observeChild(child) {
+    const collectLog = (data) => {
+      this.logTail = (this.logTail + data.toString()).slice(-MAX_LOG_TAIL_CHARACTERS);
+    };
+    child.stdout?.on('data', collectLog);
+    child.stderr?.on('data', collectLog);
+    child.once('error', (error) => { this.exitError = error; });
+    child.once('exit', (code, signal) => {
+      if (this.child === child) {
+        this.exitError = new Error(`whisper-server exited (${code ?? signal}). ${this.logTail.slice(-800)}`);
+      }
+    });
+  }
+
+  async _waitUntilHealthy() {
+    const startedAt = Date.now();
+    while (Date.now() - startedAt < STARTUP_TIMEOUT_MS) {
+      if (this.stopRequested) {
+        const error = new Error('Local Whisper startup was cancelled.');
+        error.code = 'STARTUP_CANCELLED';
+        throw error;
+      }
+      if (this.exitError) throw this.exitError;
+      try {
+        const response = await this.fetchImpl(this.healthEndpoint);
+        if (response.ok) return;
+      } catch {
+        // Connection refusal is expected until the model has finished loading.
+      }
+      await this.wait(HEALTH_POLL_MS);
+    }
+    throw new Error(`Local Whisper did not become ready in time. ${this.logTail.slice(-800)}`);
+  }
+}
+
+module.exports = {
+  WhisperServerSession,
+  LOOPBACK_HOST,
+  findFreeLoopbackPort,
+  buildMultipartBody
+};

--- a/test/local-whisper-transcriber.test.js
+++ b/test/local-whisper-transcriber.test.js
@@ -1,0 +1,93 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const { LocalWhisperTranscriber } = require('../src/local-whisper-transcriber');
+
+test('serializes both channels through one persistent session', async () => {
+  let activeInferences = 0;
+  let maximumConcurrency = 0;
+  const transcribedChannels = [];
+  const transcripts = [];
+  const fakeSession = {
+    startCalls: 0,
+    stopCalls: 0,
+    async start() { this.startCalls += 1; },
+    async transcribe(pcm) {
+      activeInferences += 1;
+      maximumConcurrency = Math.max(maximumConcurrency, activeInferences);
+      await new Promise((resolve) => setImmediate(resolve));
+      activeInferences -= 1;
+      return pcm.toString();
+    },
+    abortInferences() {},
+    async stop() { this.stopCalls += 1; }
+  };
+
+  const transcriber = new LocalWhisperTranscriber({
+    sessionOptions: {},
+    sessionFactory: () => fakeSession,
+    segmenterFactory: (options) => ({
+      push(pcm) {
+        transcribedChannels.push(options.channel);
+        options.onUtterance(options.channel, Buffer.from(pcm));
+      },
+      stop() {}
+    }),
+    onTranscript: (channel, text) => transcripts.push({ channel, text })
+  });
+
+  await transcriber.start();
+  transcriber.push('you', Buffer.from('first'));
+  transcriber.push('them', Buffer.from('second'));
+  await transcriber.queueTail;
+  await transcriber.stop();
+
+  assert.equal(fakeSession.startCalls, 1);
+  assert.equal(fakeSession.stopCalls, 1);
+  assert.equal(maximumConcurrency, 1);
+  assert.deepEqual(transcribedChannels, ['you', 'them']);
+  assert.deepEqual(transcripts, [
+    { channel: 'you', text: 'first' },
+    { channel: 'them', text: 'second' }
+  ]);
+});
+
+test('bounds shutdown drain time before aborting an in-flight inference', async () => {
+  let rejectInference;
+  const stopOptions = [];
+  const reportedErrors = [];
+  let abortCalls = 0;
+  let transcribeCalls = 0;
+  const fakeSession = {
+    async start() {},
+    async transcribe() {
+      transcribeCalls += 1;
+      return new Promise((_resolve, reject) => { rejectInference = reject; });
+    },
+    abortInferences() {
+      abortCalls += 1;
+      rejectInference(new Error('inference aborted'));
+    },
+    async stop(options) { stopOptions.push(options); }
+  };
+  const transcriber = new LocalWhisperTranscriber({
+    sessionOptions: {},
+    sessionFactory: () => fakeSession,
+    segmenterFactory: (options) => ({
+      push(pcm) { options.onUtterance(options.channel, Buffer.from(pcm)); },
+      stop() {}
+    }),
+    drainTimeoutMs: 0,
+    onError: (error) => reportedErrors.push(error)
+  });
+
+  await transcriber.start();
+  transcriber.push('you', Buffer.from('pending'));
+  transcriber.push('them', Buffer.from('discard me'));
+  await transcriber.stop();
+  await transcriber.queueTail;
+
+  assert.equal(abortCalls, 1);
+  assert.equal(transcribeCalls, 1);
+  assert.deepEqual(reportedErrors, []);
+  assert.deepEqual(stopOptions, [{ force: true }]);
+});

--- a/test/stt-provider-selection.test.js
+++ b/test/stt-provider-selection.test.js
@@ -1,0 +1,37 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const { createSTT } = require('../src/stt');
+const { createStreamingSTT } = require('../src/stt-streaming');
+
+const callbacks = {
+  onTranscript() {},
+  onInterim() {},
+  onError() {},
+  onStatusChange() {}
+};
+
+test('explicit local mode never constructs a cloud fallback', () => {
+  const settings = {
+    sttProvider: 'local',
+    apiKeys: { openai: 'openai-key', gemini: 'gemini-key', deepgram: 'deepgram-key' }
+  };
+  assert.equal(createSTT(settings).available, false);
+  assert.deepEqual(createStreamingSTT(settings, 'you', callbacks), {
+    type: 'batch',
+    provider: 'local',
+    instance: null
+  });
+});
+
+test('explicit cloud selection does not cross-fallback to another provider', () => {
+  const openai = createSTT({
+    sttProvider: 'openai',
+    apiKeys: { openai: 'openai-key', gemini: 'gemini-key' }
+  });
+  const gemini = createSTT({
+    sttProvider: 'gemini',
+    apiKeys: { openai: 'openai-key', gemini: 'gemini-key' }
+  });
+  assert.deepEqual(openai.providers, ['openai']);
+  assert.deepEqual(gemini.providers, ['gemini']);
+});

--- a/test/utterance-segmenter.test.js
+++ b/test/utterance-segmenter.test.js
@@ -1,0 +1,65 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const { UtteranceSegmenter } = require('../src/utterance-segmenter');
+
+const FRAME_SAMPLES = 480;
+const FRAME_BYTES = FRAME_SAMPLES * 2;
+
+function frame(amplitude) {
+  const buffer = Buffer.alloc(FRAME_BYTES);
+  for (let offset = 0; offset < buffer.length; offset += 2) buffer.writeInt16LE(amplitude, offset);
+  return buffer;
+}
+
+function pushFrames(segmenter, amplitude, count) {
+  for (let index = 0; index < count; index += 1) segmenter.push(frame(amplitude));
+}
+
+test('includes pre-roll and emits after the configured trailing silence', () => {
+  const utterances = [];
+  const speechStates = [];
+  const segmenter = new UtteranceSegmenter({
+    channel: 'you',
+    onSpeechState: (_channel, speaking) => speechStates.push(speaking),
+    onUtterance: (_channel, pcm) => utterances.push(pcm)
+  });
+
+  pushFrames(segmenter, 0, 10);
+  pushFrames(segmenter, 1200, 8);
+  pushFrames(segmenter, 0, 18);
+
+  assert.equal(utterances.length, 1);
+  assert.ok(utterances[0].length >= FRAME_BYTES * 30);
+  assert.deepEqual(speechStates, [true, false]);
+});
+
+test('flushes a final active utterance when capture stops', () => {
+  const utterances = [];
+  const segmenter = new UtteranceSegmenter({
+    channel: 'them',
+    onUtterance: (_channel, pcm) => utterances.push(pcm)
+  });
+  pushFrames(segmenter, 1000, 8);
+  segmenter.stop();
+  assert.equal(utterances.length, 1);
+  assert.ok(utterances[0].length >= FRAME_BYTES * 8);
+});
+
+test('splits long speech into bounded segments with overlap', () => {
+  const utterances = [];
+  const segmenter = new UtteranceSegmenter({
+    channel: 'you',
+    preRollMs: 60,
+    minUtteranceMs: 30,
+    maxUtteranceMs: 300,
+    overlapMs: 60,
+    onUtterance: (_channel, pcm) => utterances.push(pcm)
+  });
+  pushFrames(segmenter, 1000, 24);
+  segmenter.stop();
+
+  assert.ok(utterances.length >= 3);
+  assert.equal(utterances[0].length, FRAME_BYTES * 10);
+  assert.equal(utterances[1].length, FRAME_BYTES * 10);
+  assert.ok(utterances.every((pcm) => pcm.length <= FRAME_BYTES * 10));
+});

--- a/test/whisper-catalog.test.js
+++ b/test/whisper-catalog.test.js
@@ -1,0 +1,67 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+const { DEFAULT_MODEL_ID, WHISPER_MODELS, requireWhisperModel } = require('../src/whisper-model-catalog');
+const { RUNTIME_TARGETS, getRuntimeTarget, getRuntimeExecutablePath } = require('../src/whisper-runtime-manifest');
+const { locateWhisperRuntime } = require('../src/whisper-runtime');
+
+test('publishes all 30 official model choices with immutable integrity metadata', () => {
+  assert.equal(WHISPER_MODELS.length, 30);
+  assert.equal(new Set(WHISPER_MODELS.map((model) => model.id)).size, 30);
+  assert.equal(requireWhisperModel(DEFAULT_MODEL_ID).recommended, true);
+
+  for (const model of WHISPER_MODELS) {
+    assert.match(model.sha256, /^[a-f0-9]{64}$/);
+    assert.ok(model.bytes > 30_000_000);
+    assert.equal(new URL(model.url).protocol, 'https:');
+    assert.equal(model.filename, `ggml-${model.id}.bin`);
+  }
+  assert.throws(() => requireWhisperModel('../../outside'), /Unsupported Whisper model/);
+});
+
+test('defines runtime targets for Windows, Linux, and both macOS architectures', () => {
+  assert.deepEqual(Object.keys(RUNTIME_TARGETS).sort(), [
+    'darwin-arm64',
+    'darwin-x64',
+    'linux-arm64',
+    'linux-x64',
+    'win32-x64'
+  ]);
+  assert.equal(getRuntimeTarget('win32', 'x64').executable, 'whisper-server.exe');
+  assert.equal(getRuntimeTarget('darwin', 'arm64').kind, 'source');
+  assert.throws(() => getRuntimeTarget('win32', 'arm64'), /not packaged/);
+});
+
+test('locates packaged and prepared development runtimes without downloading code', (context) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'cue-runtime-locator-'));
+  context.after(() => fs.rmSync(root, { recursive: true, force: true }));
+
+  const resourcesPath = path.join(root, 'resources');
+  const packagedRuntime = path.join(resourcesPath, 'whisper-runtime');
+  fs.mkdirSync(packagedRuntime, { recursive: true });
+  fs.writeFileSync(getRuntimeExecutablePath(packagedRuntime, 'win32', 'x64'), 'runtime');
+
+  const packaged = locateWhisperRuntime({
+    isPackaged: true,
+    resourcesPath,
+    appPath: root,
+    platform: 'win32',
+    architecture: 'x64',
+    environment: {}
+  });
+  assert.equal(packaged.available, true);
+  assert.equal(packaged.target, 'win32-x64');
+
+  const missing = locateWhisperRuntime({
+    isPackaged: false,
+    resourcesPath,
+    appPath: root,
+    platform: 'linux',
+    architecture: 'arm64',
+    environment: {}
+  });
+  assert.equal(missing.available, false);
+  assert.match(missing.message, /npm run prepare:whisper/);
+});

--- a/test/whisper-model-manager.test.js
+++ b/test/whisper-model-manager.test.js
@@ -1,0 +1,155 @@
+const assert = require('node:assert/strict');
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { Readable } = require('node:stream');
+const test = require('node:test');
+const { WhisperModelManager } = require('../src/whisper-model-manager');
+
+function createFixtureModel(content) {
+  return Object.freeze({
+    id: 'fixture',
+    filename: 'ggml-fixture.bin',
+    bytes: content.length,
+    sha256: crypto.createHash('sha256').update(content).digest('hex'),
+    url: 'https://example.test/ggml-fixture.bin'
+  });
+}
+
+function createTestDirectory(context) {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'cue-model-manager-'));
+  context.after(() => fs.rmSync(directory, { recursive: true, force: true }));
+  return directory;
+}
+
+function response(status, chunks) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    body: Readable.from(chunks)
+  };
+}
+
+test('resumes, verifies, and atomically installs a model download', async (context) => {
+  const content = Buffer.from('verified model fixture');
+  const model = createFixtureModel(content);
+  const userDataPath = createTestDirectory(context);
+  let requestHeaders = null;
+  const manager = new WhisperModelManager({
+    userDataPath,
+    models: [model],
+    now: () => 1000,
+    fetchImpl: async (_url, options) => {
+      requestHeaders = options.headers;
+      return response(206, [content.subarray(8)]);
+    }
+  });
+  fs.mkdirSync(manager.modelDirectory, { recursive: true });
+  fs.writeFileSync(manager.getPartialPath(model.id), content.subarray(0, 8));
+
+  const result = await manager.download(model.id);
+  assert.equal(result.resumed, true);
+  assert.equal(requestHeaders.Range, 'bytes=8-');
+  assert.deepEqual(fs.readFileSync(manager.getModelPath(model.id)), content);
+  assert.equal(fs.existsSync(manager.getPartialPath(model.id)), false);
+  assert.equal((await manager.listModels())[0].installed, true);
+});
+
+test('removes a checksum-invalid completed download so retry can start cleanly', async (context) => {
+  const content = Buffer.from('expected bytes');
+  const model = createFixtureModel(content);
+  const manager = new WhisperModelManager({
+    userDataPath: createTestDirectory(context),
+    models: [model],
+    fetchImpl: async () => response(200, [Buffer.from('incorrect data')])
+  });
+
+  await assert.rejects(manager.download(model.id), /checksum mismatch/);
+  assert.equal(fs.existsSync(manager.getPartialPath(model.id)), false);
+  assert.equal(fs.existsSync(manager.getModelPath(model.id)), false);
+});
+
+test('replaces an incomplete destination left by an interrupted filesystem move', async (context) => {
+  const content = Buffer.from('replacement fixture');
+  const model = createFixtureModel(content);
+  const manager = new WhisperModelManager({
+    userDataPath: createTestDirectory(context),
+    models: [model],
+    fetchImpl: async () => response(200, [content])
+  });
+  fs.mkdirSync(manager.modelDirectory, { recursive: true });
+  fs.writeFileSync(manager.getModelPath(model.id), Buffer.from('short'));
+
+  await manager.download(model.id);
+  assert.deepEqual(fs.readFileSync(manager.getModelPath(model.id)), content);
+});
+
+test('replaces a zero-byte destination before the final atomic rename', async (context) => {
+  const content = Buffer.from('zero-byte replacement fixture');
+  const model = createFixtureModel(content);
+  const manager = new WhisperModelManager({
+    userDataPath: createTestDirectory(context),
+    models: [model],
+    fetchImpl: async () => response(200, [content])
+  });
+  fs.mkdirSync(manager.modelDirectory, { recursive: true });
+  fs.writeFileSync(manager.getModelPath(model.id), Buffer.alloc(0));
+
+  await manager.download(model.id);
+  assert.deepEqual(fs.readFileSync(manager.getModelPath(model.id)), content);
+});
+
+test('cancels an in-flight download while retaining resumable bytes', async (context) => {
+  const content = Buffer.from('cancel fixture');
+  const model = createFixtureModel(content);
+  let fetchStarted;
+  const started = new Promise((resolve) => { fetchStarted = resolve; });
+  const manager = new WhisperModelManager({
+    userDataPath: createTestDirectory(context),
+    models: [model],
+    fetchImpl: async (_url, options) => new Promise((_resolve, reject) => {
+      fetchStarted();
+      options.signal.addEventListener('abort', () => reject(new Error('aborted')), { once: true });
+    })
+  });
+
+  const download = manager.download(model.id);
+  await started;
+  assert.equal(manager.cancelDownload(model.id), true);
+  await assert.rejects(download, /cancelled/);
+  assert.equal(manager.activeDownload, null);
+});
+
+test('imports only a file matching the selected model integrity contract', async (context) => {
+  const content = Buffer.from('import fixture');
+  const model = createFixtureModel(content);
+  const userDataPath = createTestDirectory(context);
+  const sourcePath = path.join(userDataPath, 'source.bin');
+  fs.writeFileSync(sourcePath, content);
+  const manager = new WhisperModelManager({
+    userDataPath,
+    models: [model],
+    fetchImpl: async () => { throw new Error('not used'); }
+  });
+
+  await manager.importModel(model.id, sourcePath);
+  assert.deepEqual(fs.readFileSync(manager.getModelPath(model.id)), content);
+  await manager.deleteModel(model.id);
+  assert.equal(fs.existsSync(manager.getModelPath(model.id)), false);
+});
+
+test('reports a missing selected model distinctly from a corrupt model', async (context) => {
+  const content = Buffer.from('missing model fixture');
+  const model = createFixtureModel(content);
+  const manager = new WhisperModelManager({
+    userDataPath: createTestDirectory(context),
+    models: [model],
+    fetchImpl: async () => { throw new Error('not used'); }
+  });
+
+  await assert.rejects(
+    manager.verifyInstalledModel(model.id),
+    (error) => error.code === 'ENOENT'
+  );
+});

--- a/test/whisper-server-session.test.js
+++ b/test/whisper-server-session.test.js
@@ -1,0 +1,115 @@
+const assert = require('node:assert/strict');
+const { EventEmitter } = require('node:events');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { PassThrough } = require('node:stream');
+const test = require('node:test');
+const { WhisperServerSession, buildMultipartBody } = require('../src/whisper-server-session');
+
+class FakeChild extends EventEmitter {
+  constructor() {
+    super();
+    this.stdout = new PassThrough();
+    this.stderr = new PassThrough();
+    this.exitCode = null;
+    this.signalCode = null;
+    this.killSignals = [];
+  }
+
+  kill(signal) {
+    this.killSignals.push(signal);
+    this.exitCode = 0;
+    queueMicrotask(() => this.emit('exit', 0, signal));
+    return true;
+  }
+}
+
+test('loads one server process and reuses it for multiple in-memory inferences', async (context) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'cue-whisper-session-'));
+  context.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const executablePath = path.join(root, process.platform === 'win32' ? 'whisper-server.exe' : 'whisper-server');
+  const modelPath = path.join(root, 'ggml-fixture.bin');
+  fs.writeFileSync(executablePath, 'runtime');
+  fs.writeFileSync(modelPath, 'model');
+  fs.chmodSync(executablePath, 0o755);
+
+  const child = new FakeChild();
+  const spawnCalls = [];
+  const fetchCalls = [];
+  const session = new WhisperServerSession({
+    executablePath,
+    runtimeDirectory: root,
+    modelPath,
+    language: 'en',
+    threads: 3,
+    spawnImpl: (...args) => { spawnCalls.push(args); return child; },
+    findPort: async () => 43123,
+    randomBytes: (size) => Buffer.alloc(size, 7),
+    wait: async () => {},
+    fetchImpl: async (url, options = {}) => {
+      fetchCalls.push({ url, options });
+      if (!options.method) return { ok: true, status: 200 };
+      return { ok: true, status: 200, text: async () => JSON.stringify({ text: 'hello locally' }) };
+    }
+  });
+
+  await session.start();
+  await session.start();
+  assert.equal(spawnCalls.length, 1);
+  const argumentsList = spawnCalls[0][1];
+  assert.deepEqual(argumentsList.slice(0, 2), ['--model', modelPath]);
+  assert.ok(argumentsList.includes('--request-path'));
+  assert.ok(!argumentsList.includes('--convert'));
+
+  assert.equal(await session.transcribe(Buffer.alloc(3200)), 'hello locally');
+  assert.equal(await session.transcribe(Buffer.alloc(3200)), 'hello locally');
+  assert.equal(spawnCalls.length, 1);
+  assert.equal(fetchCalls.filter((call) => call.options.method === 'POST').length, 2);
+  assert.ok(fetchCalls.every((call) => call.url.startsWith('http://127.0.0.1:43123/cue-')));
+
+  await session.stop();
+  assert.deepEqual(child.killSignals, ['SIGTERM']);
+});
+
+test('builds a WAV multipart request entirely in memory', () => {
+  const multipart = buildMultipartBody(Buffer.from('RIFFfixture'));
+  assert.match(multipart.boundary, /^cue-[a-f0-9]+$/);
+  assert.ok(multipart.body.includes(Buffer.from('filename="audio.wav"')));
+  assert.ok(multipart.body.includes(Buffer.from('RIFFfixture')));
+});
+
+test('cancels model loading and force-terminates the sidecar', async (context) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'cue-whisper-cancel-'));
+  context.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const executablePath = path.join(root, process.platform === 'win32' ? 'whisper-server.exe' : 'whisper-server');
+  const modelPath = path.join(root, 'ggml-fixture.bin');
+  fs.writeFileSync(executablePath, 'runtime');
+  fs.writeFileSync(modelPath, 'model');
+  fs.chmodSync(executablePath, 0o755);
+
+  const child = new FakeChild();
+  let releaseHealthPoll;
+  let markHealthPollStarted;
+  const healthPollStarted = new Promise((resolve) => { markHealthPollStarted = resolve; });
+  const session = new WhisperServerSession({
+    executablePath,
+    runtimeDirectory: root,
+    modelPath,
+    spawnImpl: () => child,
+    findPort: async () => 43124,
+    fetchImpl: async () => ({ ok: false, status: 503 }),
+    wait: async () => {
+      markHealthPollStarted();
+      await new Promise((resolve) => { releaseHealthPoll = resolve; });
+    }
+  });
+
+  const startup = session.start();
+  const rejectedStartup = assert.rejects(startup, (error) => error.code === 'STARTUP_CANCELLED');
+  await healthPollStarted;
+  await session.stop({ force: true });
+  releaseHealthPoll();
+  await rejectedStartup;
+  assert.deepEqual(child.killSignals, ['SIGKILL']);
+});


### PR DESCRIPTION
## Summary

- add an independent speech-to-text provider setting with explicit Auto, Local, Deepgram, OpenAI, and Gemini modes
- run one persistent `whisper-server` per listening session, shared by the You and Them channels through a serialized inference queue
- segment in-memory PCM with adaptive VAD, 300 ms pre-roll, trailing-silence boundaries, bounded 25-second utterances, and overlap
- add a manager for all 30 models supported by whisper.cpp's official download script, including verified download/resume/cancel, import, and delete
- package a checksum-pinned whisper.cpp v1.9.1 runtime for Windows x64, Linux x64/arm64, and macOS x64/arm64
- add native runtime smoke checks and Linux release artifacts

## Privacy and lifecycle

Local mode binds only to `127.0.0.1` on a temporary port with a random request path. WAV multipart requests remain in memory; captured audio is not written to temporary files. Local mode never falls back to a cloud transcription provider.

The model loads once when listening starts. Stopping immediately rejects new audio, drains queued utterances for up to 15 seconds, then terminates the sidecar. Loading can be cancelled from the listening toggle.

## Validation

- `npm test`: 47 passing tests
- syntax checks across application, runtime scripts, and tests
- Windows runtime prepare and launch smoke test
- Linux x64 and arm64 archives prepared successfully from Windows, including materialized shared-library aliases
- real whisper.cpp end-to-end transcription of the official JFK sample twice through the same server PID
- fresh `npm run pack` build with the packaged Windows sidecar launched successfully

The PR is intentionally draft so the native Windows, Linux, and macOS checks can be reviewed before it is marked ready.