### PR TITLE
Fix packaged build: remove stale package.json build field so dist uses electron-builder.cjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,37 +14,6 @@
     "dist:mac": "electron-builder --mac zip",
     "dist:win": "electron-builder --win zip"
   },
-  "build": {
-    "appId": "com.cue.overlay",
-    "productName": "cue",
-    "asar": false,
-    "files": [
-      "main.js",
-      "preload.js",
-      "src/**/*",
-      "renderer/**/*"
-    ],
-    "mac": {
-      "target": [
-        "dir"
-      ],
-      "category": "public.app-category.productivity",
-      "hardenedRuntime": false,
-      "gatekeeperAssess": false,
-      "identity": null,
-      "extendInfo": {
-        "LSUIElement": true,
-        "NSMicrophoneUsageDescription": "cue transcribes your microphone so it can help you in conversations.",
-        "NSCameraUsageDescription": "cue does not use the camera.",
-        "NSAudioCaptureUsageDescription": "cue captures system audio to transcribe the other participant in a call."
-      }
-    },
-    "win": {
-      "target": [
-        "dir"
-      ]
-    }
-  },
   "keywords": [
     "electron",
     "overlay",


### PR DESCRIPTION
## Problem

`npm run dist:mac` produces a **macOS app that crashes on launch** with `Cannot find module '../vendor/app-link'`, even though the app runs fine from source via `npm start`.

## Root cause

The `build` field in `package.json` and `electron-builder.cjs` have drifted into two different configs. electron-builder 24 **prefers the `package.json` `build` field** over a dedicated config file, so the npm scripts (which call bare `electron-builder`) load the package.json config — not `electron-builder.cjs`.

That's contrary to the `.cjs` file's own header comment:

> electron-builder configuration. Moved out of package.json so signing can be chosen by the environment rather than hardcoded

The stale package.json config omits `vendor/**/*` from `files`. But `main.js` → `src/applink.js` does `require('../vendor/app-link')` at module-load time (it's the entry point's require chain), so the packaged app dies immediately on launch.

## Fix

Remove the stale `build` field from `package.json`. With no `build` field present, electron-builder auto-discovers `electron-builder.cjs` — the intended, complete config, which includes `vendor/**/*`, env-gated signing/notarization, and the correct Windows `nsis` target.

No new config is introduced; this just lets the existing intended config take effect.

## Verification

Before (loads package.json config, vendor missing → launch crash):
```
• loaded configuration  file=package.json ("build" field)
```
After this change, the same documented command:
```
$ npm run dist:mac
• loaded configuration  file=.../electron-builder.cjs
```
- `vendor/app-link` is present in `cue.app/Contents/Resources/app/vendor/`
- Packaged app launches with no `Cannot find module` error

Tested on macOS arm64, Node 24, electron-builder 24.13.3.