### PR TITLE
fix: enable macOS system-audio loopback and ship vendor/ in packaged app

### DIFF
--- a/main.js
+++ b/main.js
@@ -12,6 +12,15 @@ const { AdaptiveVAD, AudioRingBuffer } = require('./src/vad');
 const { buildInterviewContext, detectCategory } = require('./src/interview-context');
 const { startAppLink, stopAppLink, recordEvent, appLinkConsentState, revokeAppLinkCaller } = require('./src/applink');
 
+// macOS system-audio loopback (the "them" channel via getDisplayMedia) does not
+// start on Electron 31–38 unless these Chromium features are enabled; without
+// them getDisplayMedia rejects with "Error starting capture" and meeting audio
+// silently never works. Electron 39+ wires this up itself, where this is a
+// harmless no-op. Must run before app is ready. (Ref: electron-audio-loopback.)
+if (process.platform === 'darwin') {
+  app.commandLine.appendSwitch('enable-features', 'MacLoopbackAudioForScreenShare,MacSckSystemAudioLoopbackOverride');
+}
+
 let win = null;
 // Which global shortcuts cue actually holds. `globalShortcut.register` returns
 // false when another application already owns the combination, and nothing used

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
       "main.js",
       "preload.js",
       "src/**/*",
-      "renderer/**/*"
+      "renderer/**/*",
+      "vendor/**/*"
     ],
     "mac": {
       "target": [


### PR DESCRIPTION
## What

Two small, macOS-only fixes that make the meeting-audio ("them") channel actually work.

### 1. Enable macOS system-audio loopback (`main.js`)
`getDisplayMedia` system-audio loopback does not start on Electron **31–38** unless two Chromium features are enabled before app-ready:

```js
if (process.platform === 'darwin') {
  app.commandLine.appendSwitch('enable-features', 'MacLoopbackAudioForScreenShare,MacSckSystemAudioLoopbackOverride');
}
```

Without them, `navigator.mediaDevices.getDisplayMedia({audio:true})` rejects with `AbortError: Error starting capture`, and the renderer logs `system audio error: Error starting capture` on every listen — meeting audio silently never works. Guarded to `darwin`; a harmless no-op on Electron 39+, which wires this up internally. (Reference: [`electron-audio-loopback`](https://github.com/alectrocute/electron-audio-loopback).)

### 2. Ship `vendor/` in the packaged app (`package.json`)
`src/applink.js` does `require('../vendor/app-link')` at module load, but `vendor/**/*` was not in the packaged `files` list. A packaged build therefore **crashes at launch** with a `MODULE_NOT_FOUND` on `../vendor/app-link`. `electron-builder` loads this `package.json` `"build"` field, so this is the list that actually ships.

## Why

On macOS the "them" channel rides entirely on `getDisplayMedia`. Diagnosed by tracing the capture path and running isolated Electron probes against the app's own binary: with Screen Recording granted, capture still failed with `Error starting capture` until the loopback features were enabled. The `vendor/` omission was found when a packaged build crashed on first launch.

## Testing

- Reproduced the `Error starting capture` failure and confirmed the loopback flags are required (Electron 33, macOS).
- Confirmed a packaged build without `vendor/` crashes at launch, and that adding `vendor/**/*` fixes it.
- **macOS only.** I have not tested on Windows — both changes are either `darwin`-guarded (#1) or build-manifest only (#2), so Windows behaviour should be unaffected, but a Windows packaging check before merge would be prudent.

## Scope

Deliberately minimal — no dependency bumps. (Enabling the flags means users on the current Electron 33 get working loopback without an Electron upgrade.)
