### PR TITLE
Quiet typing: Ctrl/Cmd editing shortcuts

### DIFF
--- a/main.js
+++ b/main.js
@@ -25,6 +25,8 @@ const { WhisperModelManager } = require('./src/whisper-model-manager');
 const { requireWhisperModel } = require('./src/whisper-model-catalog');
 const { locateWhisperRuntime } = require('./src/whisper-runtime');
 const { LocalWhisperTranscriber } = require('./src/local-whisper-transcriber');
+const { installNoActivate, allowActivate, restoreNoActivate } = require('./src/no-activate');
+const { startQuietKeyboard, stopQuietKeyboard } = require('./src/quiet-keyboard');
 
 let win = null;
 // Which global shortcuts cue actually holds. `globalShortcut.register` returns
@@ -207,6 +209,9 @@ function createWindow() {
     skipTaskbar: true,
     alwaysOnTop: true,
     fullscreenable: false,
+    // Critical: cue must never take OS focus. Clicking/dragging the overlay
+    // should not blur the user's real app (meetings, browsers, coding tests).
+    focusable: false,
     webPreferences: {
       preload: path.join(__dirname, 'preload.js'),
       contextIsolation: true,
@@ -223,6 +228,10 @@ function createWindow() {
   }
 
   win = new BrowserWindow(winOptions);
+
+  // Non-activating overlay: buttons/drag don't take keyboard; composer/Settings
+  // call focus-mode (sync) on the user gesture so typing works.
+  installNoActivate(win);
 
   // Fix 2: Only call setContentProtection if the OS supports it.
   // On Windows, WDA_EXCLUDEFROMCAPTURE requires build 19041+ (Windows 10 May 2020 Update).
@@ -254,10 +263,45 @@ function createWindow() {
     }, 500);
   });
 
+  // If the saved position was on a disconnected monitor, pull it back onto
+  // the primary work area so cue does not "disappear" after relaunch.
+  win.once('ready-to-show', () => {
+    try {
+      const bounds = win.getBounds();
+      const displays = screen.getAllDisplays();
+      const visible = displays.some((d) => {
+        const a = d.workArea;
+        return bounds.x + bounds.width > a.x + 40
+          && bounds.y + 20 > a.y
+          && bounds.x < a.x + a.width - 40
+          && bounds.y < a.y + a.height - 20;
+      });
+      if (!visible) {
+        const { workArea } = screen.getPrimaryDisplay();
+        win.setPosition(
+          Math.round(workArea.x + (workArea.width - bounds.width) / 2),
+          workArea.y + 6
+        );
+      }
+    } catch (err) {
+      console.log('[cue] visible-bounds check failed', err && err.message);
+    }
+  });
+
+  win.on('closed', () => {
+    console.log('[cue] window closed');
+    win = null;
+  });
+
   win.setTitle('Microsoft Edge Update'); // set before load
 
   win.webContents.on('did-finish-load', () => {
     win.showInactive();
+    // Don't force setFocusable(false) here if the user already clicked to type
+    // before load finished (rare); installNoActivate's lock handles the default.
+    if (!win.__cueAllowFocus) {
+      try { win.setFocusable(false); } catch { /* ignore */ }
+    }
     win.setTitle('Microsoft Edge Update');
     // Warn about missing content protection on old Windows builds
     if (isWindows && shouldProtect && !WIN_SUPPORTS_CONTENT_PROTECTION) {
@@ -625,7 +669,98 @@ ipcMain.handle('transcript:clear', () => {
 ipcMain.on('ask', (_e, payload) => runFeature(payload.mode, payload.text));
 ipcMain.on('mic:pcm', (_e, arrayBuffer) => { if (state.capturing) routeAudio('you', arrayBuffer); });
 ipcMain.on('system:pcm', (_e, arrayBuffer) => { if (state.capturing) routeAudio('them', arrayBuffer); });
-ipcMain.on('mouse:ignore', (_e, v) => { if (win) win.setIgnoreMouseEvents(!!v, { forward: true }); });
+ipcMain.on('mouse:ignore', (_e, v) => {
+  if (!win || win.isDestroyed()) return;
+  // forward:true keeps mouse-move events while click-through is on.
+  win.setIgnoreMouseEvents(!!v, { forward: true });
+});
+
+// Custom window drag that never activates the window (replaces -webkit-app-region: drag).
+let dragState = null;
+ipcMain.on('drag:start', (_e, payload) => {
+  if (!win || win.isDestroyed()) return;
+  const [wx, wy] = win.getPosition();
+  dragState = {
+    originScreenX: payload && payload.screenX,
+    originScreenY: payload && payload.screenY,
+    originWinX: wx,
+    originWinY: wy
+  };
+});
+ipcMain.on('drag:move', (_e, payload) => {
+  if (!win || win.isDestroyed() || !dragState) return;
+  if (typeof payload.screenX !== 'number' || typeof payload.screenY !== 'number') return;
+  const dx = payload.screenX - dragState.originScreenX;
+  const dy = payload.screenY - dragState.originScreenY;
+  // setPosition does not activate a non-focusable / NOACTIVATE window.
+  win.setPosition(Math.round(dragState.originWinX + dx), Math.round(dragState.originWinY + dy));
+});
+ipcMain.on('drag:end', () => {
+  dragState = null;
+  if (win && !win.isDestroyed()) {
+    const [x, y] = win.getPosition();
+    store.setSettings({ windowX: x, windowY: y });
+  }
+});
+
+// Quiet typing: capture keys WITHOUT focusing the overlay (no blur on the app below).
+ipcMain.on('quiet-type-sync', (event, enabled) => {
+  if (!win || win.isDestroyed()) {
+    event.returnValue = { ok: false };
+    return;
+  }
+  try {
+    if (enabled) {
+      // Ensure overlay stays non-focusable while typing quietly.
+      restoreNoActivate(win);
+      const res = startQuietKeyboard((msg) => {
+        if (!win || win.isDestroyed()) return;
+        if (msg.type === 'down') send('quiet-key', msg);
+      });
+      event.returnValue = { ok: !!res.ok, quiet: true, error: res.error || null };
+      if (res.ok) send('status', { message: 'Typing quietly — keys go to cue, app below keeps focus. Esc to cancel.' });
+    } else {
+      stopQuietKeyboard();
+      restoreNoActivate(win);
+      event.returnValue = { ok: true, quiet: false };
+    }
+  } catch (err) {
+    console.log('[quiet-type-sync]', err && err.message);
+    event.returnValue = { ok: false, error: err && err.message };
+  }
+});
+
+// Settings still uses real focus (form fields need a caret in inputs).
+ipcMain.on('focus-mode-sync', (event, enabled) => {
+  if (!win || win.isDestroyed()) {
+    event.returnValue = { ok: false };
+    return;
+  }
+  try {
+    // Real focus mode exits quiet typing first.
+    stopQuietKeyboard();
+    if (enabled) {
+      const ok = allowActivate(win);
+      event.returnValue = { ok: !!ok, focusable: true };
+    } else {
+      restoreNoActivate(win);
+      event.returnValue = { ok: true, focusable: false };
+    }
+  } catch (err) {
+    console.log('[focus-mode-sync]', err && err.message);
+    event.returnValue = { ok: false, error: err && err.message };
+  }
+});
+ipcMain.handle('focus-mode', async (_e, enabled) => {
+  if (!win || win.isDestroyed()) return { ok: false };
+  stopQuietKeyboard();
+  if (enabled) {
+    allowActivate(win);
+    return { ok: true, focusable: true };
+  }
+  restoreNoActivate(win);
+  return { ok: true, focusable: false };
+});
 ipcMain.on('open-pane', (_e, url) => { shell.openExternal(url).catch(() => {}); });
 ipcMain.on('app:quit', () => app.quit());
 ipcMain.on('log', (_e, msg) => console.log('[renderer]', msg));
@@ -801,7 +936,9 @@ function launchApp() {
 
   createWindow();
   registerShortcuts();
+
 }
+
 
 // -------- lifecycle --------
 app.whenReady().then(async () => {
@@ -825,22 +962,27 @@ app.whenReady().then(async () => {
 });
 
 app.on('will-quit', () => {
+  console.log('[cue] will-quit');
   globalShortcut.unregisterAll();
   // Best effort, deliberately not blocking the quit: the library also removes
   // the instance file from a `process.on('exit')` handler, and a file left
   // behind is harmless anyway because readers check whether the PID is alive.
   // Delaying shutdown to tidy a directory would be the wrong trade.
   stopAppLink();
+  stopQuietKeyboard();
   if (whisperModelManager?.activeDownload) {
     whisperModelManager.cancelDownload(whisperModelManager.activeDownload.modelId);
   }
   if (localWhisperTranscriber) localWhisperTranscriber.forceStop().catch(() => {});
 });
-app.on('window-all-closed', () => app.quit());
 
-app.on('will-quit', () => { globalShortcut.unregisterAll(); });
+// Single handler — previous dual window-all-closed listeners raced and could
+// quit even while we intended to keep the permissions gate open.
 app.on('window-all-closed', (e) => {
-  // Don't quit while the permissions window is open — the user may be in System Settings
-  if (permWin) { e.preventDefault(); return; }
+  if (permWin && !permWin.isDestroyed()) {
+    if (e && typeof e.preventDefault === 'function') e.preventDefault();
+    return;
+  }
+  console.log('[cue] window-all-closed → quit');
   app.quit();
 });

--- a/main.js
+++ b/main.js
@@ -762,7 +762,15 @@ ipcMain.handle('focus-mode', async (_e, enabled) => {
   return { ok: true, focusable: false };
 });
 ipcMain.on('open-pane', (_e, url) => { shell.openExternal(url).catch(() => {}); });
-ipcMain.on('app:quit', () => app.quit());
+ipcMain.on('app:quit', () => {
+  console.log('[cue] app:quit');
+  try { app.quit(); } catch (err) { console.log('[cue] app.quit failed', err && err.message); }
+  // If something keeps the process alive (open handles, children), force exit.
+  setTimeout(() => {
+    try { app.exit(0); } catch { /* ignore */ }
+    try { process.exit(0); } catch { /* ignore */ }
+  }, 800);
+});
 ipcMain.on('log', (_e, msg) => console.log('[renderer]', msg));
 // -------- resume / job-description file import --------
 // The dialog runs in MAIN and is filtered to pdf/docx; the renderer never supplies a path.
@@ -787,7 +795,6 @@ ipcMain.handle('profile:pickDocument', async () => {
     return { canceled: false, error: (e && e.message) || String(e) };
   }
 });
-ipcMain.on('app:quit', () => app.quit());
 ipcMain.handle('applink:state', () => appLinkConsentState());
 ipcMain.handle('applink:revoke', (_e, callerId) => revokeAppLinkCaller(callerId));
 

--- a/preload.js
+++ b/preload.js
@@ -20,6 +20,27 @@ contextBridge.exposeInMainWorld('cue', {
   micPcm: (arrayBuffer) => ipcRenderer.send('mic:pcm', arrayBuffer),
   systemPcm: (arrayBuffer) => ipcRenderer.send('system:pcm', arrayBuffer),
   setIgnoreMouse: (v) => ipcRenderer.send('mouse:ignore', v),
+  // Non-activating window drag (never steals OS focus from the app below).
+  dragStart: (screenX, screenY) => ipcRenderer.send('drag:start', { screenX, screenY }),
+  dragMove: (screenX, screenY) => ipcRenderer.send('drag:move', { screenX, screenY }),
+  dragEnd: () => ipcRenderer.send('drag:end'),
+  // Quiet typing: keys via system hook, overlay does NOT take OS focus (no blur log).
+  quietTypeSync: (enabled) => {
+    try {
+      return ipcRenderer.sendSync('quiet-type-sync', !!enabled);
+    } catch (err) {
+      return { ok: false, error: String(err && err.message || err) };
+    }
+  },
+  // Settings only: real caret (will take focus).
+  focusModeSync: (enabled) => {
+    try {
+      return ipcRenderer.sendSync('focus-mode-sync', !!enabled);
+    } catch (err) {
+      return { ok: false, error: String(err && err.message || err) };
+    }
+  },
+  focusMode: (enabled) => ipcRenderer.invoke('focus-mode', !!enabled),
   clearTranscript: () => ipcRenderer.invoke('transcript:clear'),
   openPane: (url) => ipcRenderer.send('open-pane', url),
   appLinkState: () => ipcRenderer.invoke('applink:state'),
@@ -32,7 +53,7 @@ contextBridge.exposeInMainWorld('cue', {
   permissionsContinue: () => ipcRenderer.send('permissions:continue'),
   log: (msg) => ipcRenderer.send('log', msg),
   on: (channel, cb) => {
-    const allowed = ['capture:state', 'llm:start', 'llm:token', 'llm:done', 'llm:error', 'status', 'transcript', 'stt:interim', 'stt:final', 'stt:status', 'vad:state', 'applink:consent-request', 'hide:toggle', 'whisper:download-progress', 'whisper:models-changed'];
+    const allowed = ['capture:state', 'llm:start', 'llm:token', 'llm:done', 'llm:error', 'status', 'transcript', 'stt:interim', 'stt:final', 'stt:status', 'vad:state', 'applink:consent-request', 'hide:toggle', 'whisper:download-progress', 'whisper:models-changed', 'quiet-key'];
     if (!allowed.includes(channel)) return;
     ipcRenderer.on(channel, (_e, data) => cb(data));
   }

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -58,6 +58,8 @@
               <div id="input-area">
                 <div id="placeholder">Ask about your screen or conversation, or <span class="keycap">⌘</span><span class="keycap">⏎</span> for Assist</div>
                 <textarea id="input" rows="1" spellcheck="false"></textarea>
+                <!-- Fake caret for quiet-typing (tracks text without OS focus) -->
+                <div id="quiet-caret" class="hidden" aria-hidden="true"></div>
               </div>
               <div id="composer-bottom">
                 <button id="smart-toggle" class="smart-pill"><span class="ic"></span><span>Smart</span></button>

--- a/renderer/renderer.js
+++ b/renderer/renderer.js
@@ -21,6 +21,69 @@
   const clearIC = document.querySelector('#clear-transcript-btn .ic');
   if (clearIC) clearIC.innerHTML = icon('trash-2', { size: 15 });
 
+  // ---- non-activating UI -------------------------------------------------
+  // Overlay controls are hit-tested (pointer events) but must never take OS
+  // focus, so the app underneath (browser, IDE, meeting) does not blur.
+  function hardenNoFocus(root) {
+    const scope = root || document;
+    scope.querySelectorAll('button, a, [role="button"], input, textarea, select').forEach((el) => {
+      // Settings form fields are allowed focus only while focus-mode is on.
+      if (el.closest && el.closest('#settings, #onboard, #consent-scrim')) return;
+      try { el.tabIndex = -1; } catch { /* ignore */ }
+      if (el.tagName === 'TEXTAREA' || el.tagName === 'INPUT') {
+        // Keep value editable by script/STT; block caret unless focus-mode.
+        el.setAttribute('data-no-focus', '1');
+      }
+    });
+  }
+  hardenNoFocus(document);
+
+  // Buttons: fire on pointerup in-bounds (hit test), never steal focus on mousedown.
+  document.addEventListener('mousedown', (e) => {
+    const t = e.target && e.target.closest && e.target.closest('button, .act, .smart-pill, .more-btn, .drag-pill');
+    if (!t) return;
+    // Allow settings/onboard to focus fields when focus-mode is enabled.
+    if (t.closest && t.closest('#settings-scrim, #onboard-scrim, #consent-scrim')) return;
+    e.preventDefault(); // prevents focus transfer that would blur the app below
+  }, true);
+
+  // Custom window drag — screen coordinates, no -webkit-app-region activation.
+  (function setupCustomDrag() {
+    const handle = document.querySelector('.drag-pill') || document.querySelector('#toolbar');
+    if (!handle || !cue.dragStart) return;
+    let dragging = false;
+    handle.addEventListener('pointerdown', (e) => {
+      // Only primary button; ignore clicks on toolbar buttons inside the pill row.
+      if (e.button !== 0) return;
+      if (e.target && e.target.closest && e.target.closest('button')) return;
+      dragging = true;
+      handle.classList.add('dragging');
+      try { handle.setPointerCapture(e.pointerId); } catch { /* ignore */ }
+      e.preventDefault();
+      cue.dragStart(e.screenX, e.screenY);
+    });
+    handle.addEventListener('pointermove', (e) => {
+      if (!dragging) return;
+      cue.dragMove(e.screenX, e.screenY);
+    });
+    function endDrag(e) {
+      if (!dragging) return;
+      dragging = false;
+      handle.classList.remove('dragging');
+      try { if (e && e.pointerId != null) handle.releasePointerCapture(e.pointerId); } catch { /* ignore */ }
+      cue.dragEnd();
+    }
+    handle.addEventListener('pointerup', endDrag);
+    handle.addEventListener('pointercancel', endDrag);
+    // Safety: if capture is lost
+    handle.addEventListener('lostpointercapture', () => {
+      if (!dragging) return;
+      dragging = false;
+      handle.classList.remove('dragging');
+      cue.dragEnd();
+    });
+  })();
+
   // ---- state -------------------------------------------------------------
   let settings = null;
   let whisperOverview = null;
@@ -31,6 +94,62 @@
   const MAX_RESPONSES = 20;
 
   const messages = $('#messages');
+
+  // ---- lock the overlay shell -------------------------------------------
+  // The transparent BrowserWindow must never pan. Only panes that opt in
+  // (messages, settings tab bodies, textarea, code blocks) may scroll.
+  function isScrollableTarget(el) {
+    let node = el;
+    while (node && node !== document.documentElement) {
+      if (node.nodeType === 1) {
+        const tag = node.tagName;
+        if (tag === 'TEXTAREA' || tag === 'SELECT') return true;
+        if (node.id === 'messages' || node.id === 'transcript-list') return true;
+        if (node.classList && (
+          node.classList.contains('s-tab-pane') ||
+          node.classList.contains('s-body') ||
+          node.classList.contains('ai-code') ||
+          node.classList.contains('ob-body')
+        )) return true;
+        try {
+          const style = window.getComputedStyle(node);
+          const oy = style && style.overflowY;
+          if ((oy === 'auto' || oy === 'scroll') && node.scrollHeight > node.clientHeight + 1) {
+            return true;
+          }
+        } catch (_) { /* ignore */ }
+      }
+      node = node.parentElement;
+    }
+    return false;
+  }
+
+  function pinOverlayScroll() {
+    if (window.scrollX || window.scrollY) window.scrollTo(0, 0);
+    if (document.documentElement) {
+      document.documentElement.scrollTop = 0;
+      document.documentElement.scrollLeft = 0;
+    }
+    if (document.body) {
+      document.body.scrollTop = 0;
+      document.body.scrollLeft = 0;
+    }
+  }
+
+  window.addEventListener('scroll', pinOverlayScroll, { passive: true, capture: true });
+  document.addEventListener('scroll', pinOverlayScroll, { passive: true, capture: true });
+  // Block wheel/trackpad panning of the window chrome; allow it inside panes.
+  window.addEventListener('wheel', (e) => {
+    if (!isScrollableTarget(e.target)) {
+      e.preventDefault();
+      pinOverlayScroll();
+    }
+  }, { passive: false, capture: true });
+  // Focus changes (e.g. focusing the composer) must not jump the window.
+  window.addEventListener('focusin', () => {
+    requestAnimationFrame(pinOverlayScroll);
+  }, true);
+  pinOverlayScroll();
 
   function esc(s) { return s.replace(/[&<>"]/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c])); }
 
@@ -474,9 +593,287 @@
     syncPlaceholder();
     updateSendButtonState(); // FIX #9: Update send button on input change
   });
-  input.addEventListener('focus', () => { composer.classList.add('focused'); placeholder.classList.add('hidden'); });
-  input.addEventListener('blur', () => { composer.classList.remove('focused'); syncPlaceholder(); });
-  $('#input-area').addEventListener('click', () => input.focus());
+  // Quiet typing: system key hook feeds the composer WITHOUT focusing cue,
+  // so the app underneath never blurs / never logs focus events.
+  // A fake caret tracks the insertion point (real textarea caret needs OS focus).
+  let typingArmed = false;
+  let quietCursor = 0; // insertion index into input.value
+  const quietCaretEl = document.getElementById('quiet-caret');
+  let quietMirror = null;
+  let quietMeasureCanvas = null;
+
+  function ensureQuietMirror() {
+    if (quietMirror && quietMirror.isConnected) return quietMirror;
+    quietMirror = document.createElement('div');
+    quietMirror.id = 'quiet-caret-mirror';
+    quietMirror.setAttribute('aria-hidden', 'true');
+    const area = document.getElementById('input-area');
+    if (area) area.appendChild(quietMirror);
+    return quietMirror;
+  }
+
+  function syncQuietMirrorStyles() {
+    const mirror = ensureQuietMirror();
+    const cs = window.getComputedStyle(input);
+    // Match textarea text metrics exactly so caret x/y land on the glyph edge.
+    mirror.style.font = cs.font;
+    mirror.style.fontSize = cs.fontSize;
+    mirror.style.fontFamily = cs.fontFamily;
+    mirror.style.fontWeight = cs.fontWeight;
+    mirror.style.fontStyle = cs.fontStyle;
+    mirror.style.letterSpacing = cs.letterSpacing;
+    mirror.style.lineHeight = cs.lineHeight;
+    mirror.style.padding = cs.padding;
+    mirror.style.border = cs.border;
+    mirror.style.boxSizing = cs.boxSizing;
+    mirror.style.width = input.clientWidth + 'px';
+    mirror.style.whiteSpace = 'pre-wrap';
+    mirror.style.wordWrap = 'break-word';
+  }
+
+  function measureTextWidth(str, font) {
+    if (!quietMeasureCanvas) quietMeasureCanvas = document.createElement('canvas');
+    const ctx = quietMeasureCanvas.getContext('2d');
+    if (!ctx) return str.length * 8;
+    ctx.font = font;
+    return ctx.measureText(str || '').width;
+  }
+
+  function updateQuietCaret() {
+    if (!quietCaretEl) return;
+    if (!typingArmed) {
+      quietCaretEl.classList.add('hidden');
+      return;
+    }
+    quietCaretEl.classList.remove('hidden');
+
+    const value = input.value || '';
+    quietCursor = Math.max(0, Math.min(quietCursor, value.length));
+
+    syncQuietMirrorStyles();
+    const mirror = ensureQuietMirror();
+    const cs = window.getComputedStyle(input);
+    const lineHeight = parseFloat(cs.lineHeight) || 22;
+    const padL = parseFloat(cs.paddingLeft) || 0;
+    const padT = parseFloat(cs.paddingTop) || 0;
+
+    // Build mirror: text before caret + a zero-width marker span we can offset.
+    const before = value.slice(0, quietCursor);
+    const after = value.slice(quietCursor);
+    // Use a marker char that collapses to caret position
+    mirror.innerHTML = '';
+    const pre = document.createElement('span');
+    pre.textContent = before;
+    const mark = document.createElement('span');
+    mark.id = 'quiet-caret-mark';
+    mark.textContent = '\u200b'; // zero-width space
+    const post = document.createElement('span');
+    post.textContent = after;
+    mirror.append(pre, mark, post);
+
+    // Force layout then read marker position relative to input-area
+    const area = document.getElementById('input-area');
+    const areaRect = area.getBoundingClientRect();
+    const markRect = mark.getBoundingClientRect();
+    let x = markRect.left - areaRect.left;
+    let y = markRect.top - areaRect.top;
+
+    // Fallback if mirror is empty / not laid out yet
+    if (!before && (x === 0 && y === 0)) {
+      x = padL;
+      y = padT;
+    }
+
+    // Keep caret inside the visible input box
+    const maxX = Math.max(0, input.clientWidth - 2);
+    const maxY = Math.max(0, (input.clientHeight || lineHeight) - 2);
+    x = Math.max(0, Math.min(x, maxX));
+    y = Math.max(0, Math.min(y, maxY));
+
+    quietCaretEl.style.height = Math.min(18, lineHeight - 2) + 'px';
+    quietCaretEl.style.transform = `translate(${Math.round(x)}px, ${Math.round(y)}px)`;
+    // Restart blink so it stays solid right after a keystroke
+    quietCaretEl.style.animation = 'none';
+    // force reflow
+    void quietCaretEl.offsetWidth;
+    quietCaretEl.style.animation = '';
+
+    // Scroll textarea so the caret line stays visible
+    try {
+      const lineIndex = before.split('\n').length - 1;
+      const targetTop = lineIndex * lineHeight;
+      if (targetTop < input.scrollTop) input.scrollTop = targetTop;
+      if (targetTop + lineHeight > input.scrollTop + input.clientHeight) {
+        input.scrollTop = targetTop + lineHeight - input.clientHeight;
+      }
+    } catch { /* ignore */ }
+  }
+
+  function setQuietValue(next, cursor) {
+    input.value = next;
+    quietCursor = Math.max(0, Math.min(cursor, next.length));
+    // Keep native selection in sync (harmless without focus, useful if focus fallback)
+    try { input.setSelectionRange(quietCursor, quietCursor); } catch { /* ignore */ }
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    // Grow textarea height like the normal input handler
+    try {
+      input.style.height = 'auto';
+      input.style.height = Math.min(input.scrollHeight, 140) + 'px';
+    } catch { /* ignore */ }
+    syncPlaceholder();
+    updateSendButtonState();
+    updateQuietCaret();
+  }
+
+  function insertQuietText(chunk) {
+    if (!chunk) return;
+    const v = input.value || '';
+    const next = v.slice(0, quietCursor) + chunk + v.slice(quietCursor);
+    setQuietValue(next, quietCursor + chunk.length);
+  }
+
+  function applyQuietKey(msg) {
+    if (!typingArmed || !msg || msg.type !== 'down') return;
+    const { key, text, ctrl, alt, meta } = msg;
+    const v = input.value || '';
+
+    if (key === 'Escape') {
+      disarmTyping();
+      return;
+    }
+    if (key === 'Enter' && !ctrl && !alt && !meta) {
+      send();
+      disarmTyping();
+      return;
+    }
+    if (key === 'ArrowLeft') {
+      quietCursor = ctrl ? 0 : Math.max(0, quietCursor - 1);
+      updateQuietCaret();
+      return;
+    }
+    if (key === 'ArrowRight') {
+      quietCursor = ctrl ? v.length : Math.min(v.length, quietCursor + 1);
+      updateQuietCaret();
+      return;
+    }
+    if (key === 'Home' || (key === 'ArrowUp' && ctrl)) {
+      // start of current line
+      const lineStart = v.lastIndexOf('\n', Math.max(0, quietCursor - 1)) + 1;
+      quietCursor = lineStart;
+      updateQuietCaret();
+      return;
+    }
+    if (key === 'End' || (key === 'ArrowDown' && ctrl)) {
+      const nextNl = v.indexOf('\n', quietCursor);
+      quietCursor = nextNl === -1 ? v.length : nextNl;
+      updateQuietCaret();
+      return;
+    }
+    if (key === 'Backspace') {
+      if (ctrl) {
+        setQuietValue(v.slice(quietCursor), 0);
+      } else if (quietCursor > 0) {
+        setQuietValue(v.slice(0, quietCursor - 1) + v.slice(quietCursor), quietCursor - 1);
+      } else {
+        updateQuietCaret();
+      }
+      return;
+    }
+    if (key === 'Delete') {
+      if (quietCursor < v.length) {
+        setQuietValue(v.slice(0, quietCursor) + v.slice(quietCursor + 1), quietCursor);
+      } else {
+        updateQuietCaret();
+      }
+      return;
+    }
+    // Printable text
+    if (text && text.length && !ctrl && !alt && !meta) {
+      insertQuietText(text);
+      return;
+    }
+    // Ctrl+V paste
+    if ((ctrl || meta) && (key === 'v' || key === 'V')) {
+      if (navigator.clipboard && navigator.clipboard.readText) {
+        navigator.clipboard.readText().then((t) => {
+          if (!t || !typingArmed) return;
+          insertQuietText(t);
+        }).catch(() => {});
+      }
+    }
+  }
+
+  function armTyping() {
+    if (typingArmed) {
+      updateQuietCaret();
+      return;
+    }
+    typingArmed = true;
+    input.tabIndex = -1; // never OS-focus the textarea
+    try { input.blur(); } catch { /* ignore */ }
+    quietCursor = (input.value || '').length;
+    composer.classList.add('focused', 'quiet-typing');
+    placeholder.classList.add('hidden');
+    updateQuietCaret();
+
+    let result = { ok: false };
+    if (cue.quietTypeSync) {
+      result = cue.quietTypeSync(true) || result;
+    }
+    if (!result.ok) {
+      // Fallback: old focus path (will blur the app below)
+      cue.log && cue.log('[armTyping] quiet hook failed, falling back to focus: ' + (result.error || ''));
+      if (cue.focusModeSync) cue.focusModeSync(true);
+      try { input.focus({ preventScroll: true }); } catch { try { input.focus(); } catch { /* ignore */ } }
+      if (quietCaretEl) quietCaretEl.classList.add('hidden');
+    }
+  }
+
+  function disarmTyping() {
+    if (!typingArmed) {
+      if (cue.quietTypeSync) try { cue.quietTypeSync(false); } catch { /* ignore */ }
+      if (quietCaretEl) quietCaretEl.classList.add('hidden');
+      return;
+    }
+    typingArmed = false;
+    composer.classList.remove('focused', 'quiet-typing');
+    if (quietCaretEl) quietCaretEl.classList.add('hidden');
+    syncPlaceholder();
+    if (cue.quietTypeSync) {
+      try { cue.quietTypeSync(false); } catch { /* ignore */ }
+    }
+    if (cue.focusModeSync) {
+      try { cue.focusModeSync(false); } catch { /* ignore */ }
+    }
+  }
+
+  if (cue.on) {
+    cue.on('quiet-key', (msg) => applyQuietKey(msg));
+  }
+  // Keep caret aligned if the panel is resized while typing
+  window.addEventListener('resize', () => { if (typingArmed) updateQuietCaret(); });
+
+  // Click composer → arm quiet typing (no OS focus).
+  const armOnGesture = (e) => {
+    if (e.button != null && e.button !== 0) return;
+    if (e.target && e.target.closest && e.target.closest('#send-btn, button')) return;
+    e.preventDefault();
+    e.stopPropagation();
+    armTyping();
+  };
+  $('#input-area').addEventListener('pointerdown', armOnGesture, true);
+  input.addEventListener('pointerdown', armOnGesture, true);
+  input.addEventListener('mousedown', (e) => { e.preventDefault(); e.stopPropagation(); }, true);
+
+  // Clicking other cue chrome ends quiet typing (except send, which needs the text).
+  document.addEventListener('pointerdown', (e) => {
+    if (!typingArmed) return;
+    const t = e.target;
+    if (!t || !t.closest) return;
+    if (t.closest('#input-area, #input, #send-btn')) return;
+    if (t.closest('#settings-scrim, #onboard-scrim, #consent-scrim')) return;
+    if (t.closest('#toolbar, #panel-wrap, button, .act')) disarmTyping();
+  }, true);
 
   function send() {
     const text = input.value.trim();
@@ -487,6 +884,7 @@
     saveToQuestionHistory(text);
     
     input.value = '';
+    quietCursor = 0;
     inputFromSTT = false;
     lastSTTValue = ''; // FIX #6: Clear tracked STT value
     userSpeechStart = null;
@@ -496,6 +894,7 @@
     clearTimeout(sttFillTimer);
     syncPlaceholder();
     updateSendButtonState(); // FIX #9
+    if (typingArmed) updateQuietCaret();
     
     // If text came from STT (interviewer question), use answerThis mode
     // Otherwise use ask mode (user typed their own question)
@@ -1089,9 +1488,13 @@
     aiEl.appendChild(caretEl);
     group.appendChild(aiEl);
     messages.appendChild(group);
-    // Use requestAnimationFrame so the DOM is fully updated before scrolling
+    // Scroll only inside #messages — never use Element.scrollIntoView, which
+    // can pan the whole transparent BrowserWindow and leave just the drag bar
+    // visible on screen.
     requestAnimationFrame(() => {
-      if (sep && sep.isConnected) sep.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      try {
+        messages.scrollTop = Math.max(0, messages.scrollHeight - messages.clientHeight);
+      } catch (_) { /* ignore */ }
     });
     setBusy(true);
   });
@@ -1222,16 +1625,25 @@
 
   // ---- settings ----------------------------------------------------------
   const scrim = $('#settings-scrim');
-  function openSettings() { fillSettings(); scrim.classList.remove('hidden'); }
-  async function closeSettings() {
-    if (await saveSettings()) scrim.classList.add('hidden');
-  }
   function openSettings() {
+    typingArmed = true;
+    // SYNC so settings fields can type immediately.
+    if (cue.focusModeSync) cue.focusModeSync(true);
+    else if (cue.focusMode) cue.focusMode(true);
     fillSettings();
     scrim.classList.remove('hidden');
     refreshWhisperModels();
   }
-  function closeSettings() { saveSettings(); scrim.classList.add('hidden'); }
+  async function closeSettings() {
+    const ok = await saveSettings();
+    if (!ok) return false;
+    scrim.classList.add('hidden');
+    try { if (document.activeElement && document.activeElement.blur) document.activeElement.blur(); } catch { /* ignore */ }
+    typingArmed = false;
+    if (cue.focusModeSync) cue.focusModeSync(false);
+    else if (cue.focusMode) cue.focusMode(false);
+    return true;
+  }
   $('#more-btn').addEventListener('click', openSettings);
   $('#s-close').addEventListener('click', () => { void closeSettings(); });
   scrim.addEventListener('click', (e) => { if (e.target === scrim) void closeSettings(); });
@@ -1350,14 +1762,24 @@
   });
 
   function statusText() {
-    const k = settings.apiKeys;
-    const labels = { openai: 'OpenAI', anthropic: 'Anthropic', gemini: 'Gemini', deepgram: 'Deepgram', custom: 'Custom', ollama: 'Ollama', groq: 'Groq', minimax: 'MiniMax', azure: 'Azure AI Foundry' };
-    const has = Object.keys(labels).filter((p) => k[p]).map((p) => labels[p]);
+    const k = settings.apiKeys || {};
+    const labels = {
+      openai: 'OpenAI',
+      anthropic: 'Anthropic',
+      gemini: 'Gemini',
+      deepgram: 'Deepgram',
+      custom: 'Custom',
+      ollama: 'Ollama',
+      groq: 'Groq',
+      minimax: 'MiniMax',
+      azure: 'Azure AI Foundry'
+    };
     // 'auto' walks the same fallback chain src/stt.js builds; an explicit choice
     // is reported as-is so the status line matches what will actually be used.
     const selectedSttProvider = settings.sttProvider || 'auto';
     const automaticStt = k.deepgram ? 'Deepgram (streaming)' : (k.openai ? 'OpenAI Realtime' : (k.groq ? 'Groq Whisper' : (k.gemini ? 'Gemini (batch)' : 'none')));
-    const stt = selectedSttProvider === 'auto' ? automaticStt : selectedSttProvider;
+    const sttLabels = { local: 'Local whisper', deepgram: 'Deepgram', openai: 'OpenAI', gemini: 'Gemini', auto: automaticStt };
+    const stt = selectedSttProvider === 'auto' ? automaticStt : (sttLabels[selectedSttProvider] || selectedSttProvider);
     const ready = [
       settings.resumeText ? '✓ resume' : null,
       settings.jobDescription ? '✓ JD' : null,
@@ -1531,6 +1953,7 @@
 
   async function saveSettings() {
     // Keys
+    if (!settings.apiKeys) settings.apiKeys = {};
     settings.apiKeys.openai = $('#key-openai').value.trim();
     settings.apiKeys.anthropic = $('#key-anthropic').value.trim();
     settings.apiKeys.gemini = $('#key-gemini').value.trim();
@@ -1542,6 +1965,7 @@
     settings.apiKeys.minimax = $('#key-minimax').value.trim();
     settings.apiKeys.azure = $('#key-azure').value.trim();
     settings.azureEndpoint = $('#azure-endpoint').value.trim();
+    if (!settings.models) settings.models = {};
     if (!settings.models[settings.provider]) settings.models[settings.provider] = {};
     settings.models[settings.provider].fast = $('#model-fast').value.trim();
     settings.models[settings.provider].smart = $('#model-smart').value.trim();
@@ -1572,7 +1996,7 @@
     } catch (error) {
       const message = error && error.message ? error.message : String(error);
       $('#s-status').textContent = message;
-      $('#base-url').focus();
+      // Don't steal focus on validation errors in the main overlay path.
       return false;
     }
   }
@@ -1628,7 +2052,7 @@
     // Do not wait for a mousemove to turn the mouse back on: the pointer may
     // already be still, and the sheet would be unclickable until it moved.
     setIgnore(false);
-    $('#cs-deny').focus();
+    // Do not focus consent buttons — would steal focus from the app below.
   });
 
   $('#cs-allow').addEventListener('click', () => answerConsent(true));

--- a/renderer/renderer.js
+++ b/renderer/renderer.js
@@ -11,6 +11,21 @@
   $('.tb-hide .chev').innerHTML = icon('chevron-down', { size: 14 });
   $('#stop-btn').innerHTML = icon('stop-square', { size: 15 });
   $('#quit-btn').innerHTML = icon('x', { size: 14 });
+  // Quit was icon-only — never wired. Use both click and pointerup so the
+  // toolbar drag region cannot swallow the gesture on Windows.
+  const quitBtn = $('#quit-btn');
+  if (quitBtn) {
+    quitBtn.title = isWindows ? 'Quit cue (Ctrl+Shift+X)' : 'Quit cue (⌘⇧X)';
+    const doQuit = (e) => {
+      if (e) { e.preventDefault(); e.stopPropagation(); }
+      try { cue.quit(); } catch (err) { cue.log && cue.log('[quit] ' + (err && err.message)); }
+    };
+    quitBtn.addEventListener('click', doQuit);
+    quitBtn.addEventListener('pointerup', (e) => {
+      if (e.button !== 0) return;
+      doQuit(e);
+    });
+  }
   document.querySelector('.act[data-mode="assist"] .ic').innerHTML = icon('sparkles', { size: 16 });
   document.querySelector('.act[data-mode="say"] .ic').innerHTML = icon('wand-sparkles', { size: 16 });
   document.querySelector('.act[data-mode="followup"] .ic').innerHTML = icon('message-circle', { size: 16 });

--- a/renderer/renderer.js
+++ b/renderer/renderer.js
@@ -610,12 +610,82 @@
   });
   // Quiet typing: system key hook feeds the composer WITHOUT focusing cue,
   // so the app underneath never blurs / never logs focus events.
-  // A fake caret tracks the insertion point (real textarea caret needs OS focus).
+  // A fake caret + selection range track editing without OS focus.
   let typingArmed = false;
-  let quietCursor = 0; // insertion index into input.value
+  let quietCursor = 0; // active end of selection / insertion index
+  let quietAnchor = null; // null = collapsed caret; set while extending selection
   const quietCaretEl = document.getElementById('quiet-caret');
   let quietMirror = null;
   let quietMeasureCanvas = null;
+
+  function quietSelRange() {
+    const vLen = (input.value || '').length;
+    const cur = Math.max(0, Math.min(quietCursor, vLen));
+    if (quietAnchor == null) return { start: cur, end: cur };
+    const a = Math.max(0, Math.min(quietAnchor, vLen));
+    return { start: Math.min(a, cur), end: Math.max(a, cur) };
+  }
+
+  function hasQuietSel() {
+    const { start, end } = quietSelRange();
+    return end > start;
+  }
+
+  function clearQuietSel() {
+    quietAnchor = null;
+  }
+
+  function setQuietCursor(pos, { extend = false } = {}) {
+    const vLen = (input.value || '').length;
+    const next = Math.max(0, Math.min(pos, vLen));
+    if (extend) {
+      if (quietAnchor == null) quietAnchor = quietCursor;
+    } else {
+      quietAnchor = null;
+    }
+    quietCursor = next;
+    try {
+      const { start, end } = quietSelRange();
+      input.setSelectionRange(start, end);
+    } catch { /* ignore */ }
+    updateQuietCaret();
+  }
+
+  function isWordChar(ch) {
+    return !!ch && /[A-Za-z0-9_]/.test(ch);
+  }
+
+  function wordLeft(v, i) {
+    let p = Math.max(0, Math.min(i, v.length));
+    while (p > 0 && /\s/.test(v[p - 1])) p--;
+    if (p > 0 && !isWordChar(v[p - 1])) {
+      // punctuation cluster
+      while (p > 0 && !isWordChar(v[p - 1]) && !/\s/.test(v[p - 1])) p--;
+    } else {
+      while (p > 0 && isWordChar(v[p - 1])) p--;
+    }
+    return p;
+  }
+
+  function wordRight(v, i) {
+    let p = Math.max(0, Math.min(i, v.length));
+    while (p < v.length && /\s/.test(v[p])) p++;
+    if (p < v.length && !isWordChar(v[p])) {
+      while (p < v.length && !isWordChar(v[p]) && !/\s/.test(v[p])) p++;
+    } else {
+      while (p < v.length && isWordChar(v[p])) p++;
+    }
+    return p;
+  }
+
+  function lineStartAt(v, i) {
+    return v.lastIndexOf('\n', Math.max(0, i - 1)) + 1;
+  }
+
+  function lineEndAt(v, i) {
+    const nextNl = v.indexOf('\n', i);
+    return nextNl === -1 ? v.length : nextNl;
+  }
 
   function ensureQuietMirror() {
     if (quietMirror && quietMirror.isConnected) return quietMirror;
@@ -658,12 +728,17 @@
     if (!quietCaretEl) return;
     if (!typingArmed) {
       quietCaretEl.classList.add('hidden');
+      if (quietMirror) quietMirror.classList.remove('sel-visible');
       return;
     }
-    quietCaretEl.classList.remove('hidden');
 
     const value = input.value || '';
     quietCursor = Math.max(0, Math.min(quietCursor, value.length));
+    if (quietAnchor != null) {
+      quietAnchor = Math.max(0, Math.min(quietAnchor, value.length));
+    }
+    const { start, end } = quietSelRange();
+    const selected = end > start;
 
     syncQuietMirrorStyles();
     const mirror = ensureQuietMirror();
@@ -672,29 +747,59 @@
     const padL = parseFloat(cs.paddingLeft) || 0;
     const padT = parseFloat(cs.paddingTop) || 0;
 
-    // Build mirror: text before caret + a zero-width marker span we can offset.
-    const before = value.slice(0, quietCursor);
-    const after = value.slice(quietCursor);
-    // Use a marker char that collapses to caret position
+    // Mirror: optional selection highlight + zero-width mark at active caret end.
     mirror.innerHTML = '';
-    const pre = document.createElement('span');
-    pre.textContent = before;
     const mark = document.createElement('span');
     mark.id = 'quiet-caret-mark';
-    mark.textContent = '\u200b'; // zero-width space
-    const post = document.createElement('span');
-    post.textContent = after;
-    mirror.append(pre, mark, post);
+    mark.textContent = '\u200b';
+
+    function spanText(str, className) {
+      const el = document.createElement('span');
+      if (className) el.className = className;
+      el.textContent = str;
+      return el;
+    }
+
+    if (!selected) {
+      mirror.append(spanText(value.slice(0, quietCursor)), mark, spanText(value.slice(quietCursor)));
+    } else if (quietCursor <= start) {
+      // Active end on the left of the range
+      mirror.append(
+        spanText(value.slice(0, quietCursor)),
+        mark,
+        spanText(value.slice(start, end), 'quiet-sel'),
+        spanText(value.slice(end))
+      );
+    } else if (quietCursor >= end) {
+      mirror.append(
+        spanText(value.slice(0, start)),
+        spanText(value.slice(start, end), 'quiet-sel'),
+        mark,
+        spanText(value.slice(end))
+      );
+    } else {
+      // Active end inside the range
+      mirror.append(
+        spanText(value.slice(0, start)),
+        spanText(value.slice(start, quietCursor), 'quiet-sel'),
+        mark,
+        spanText(value.slice(quietCursor, end), 'quiet-sel'),
+        spanText(value.slice(end))
+      );
+    }
+
+    mirror.classList.toggle('sel-visible', selected);
 
     // Force layout then read marker position relative to input-area
     const area = document.getElementById('input-area');
+    const markEl = document.getElementById('quiet-caret-mark') || mark;
     const areaRect = area.getBoundingClientRect();
-    const markRect = mark.getBoundingClientRect();
+    const markRect = markEl.getBoundingClientRect();
     let x = markRect.left - areaRect.left;
     let y = markRect.top - areaRect.top;
 
     // Fallback if mirror is empty / not laid out yet
-    if (!before && (x === 0 && y === 0)) {
+    if (!value && (x === 0 && y === 0)) {
       x = padL;
       y = padT;
     }
@@ -705,17 +810,23 @@
     x = Math.max(0, Math.min(x, maxX));
     y = Math.max(0, Math.min(y, maxY));
 
-    quietCaretEl.style.height = Math.min(18, lineHeight - 2) + 'px';
-    quietCaretEl.style.transform = `translate(${Math.round(x)}px, ${Math.round(y)}px)`;
-    // Restart blink so it stays solid right after a keystroke
-    quietCaretEl.style.animation = 'none';
-    // force reflow
-    void quietCaretEl.offsetWidth;
-    quietCaretEl.style.animation = '';
+    // Hide caret while a range is selected (selection paint is enough).
+    if (selected) {
+      quietCaretEl.classList.add('hidden');
+    } else {
+      quietCaretEl.classList.remove('hidden');
+      quietCaretEl.style.height = Math.min(18, lineHeight - 2) + 'px';
+      quietCaretEl.style.transform = `translate(${Math.round(x)}px, ${Math.round(y)}px)`;
+      // Restart blink so it stays solid right after a keystroke
+      quietCaretEl.style.animation = 'none';
+      void quietCaretEl.offsetWidth;
+      quietCaretEl.style.animation = '';
+    }
 
     // Scroll textarea so the caret line stays visible
     try {
-      const lineIndex = before.split('\n').length - 1;
+      const beforeCaret = value.slice(0, quietCursor);
+      const lineIndex = beforeCaret.split('\n').length - 1;
       const targetTop = lineIndex * lineHeight;
       if (targetTop < input.scrollTop) input.scrollTop = targetTop;
       if (targetTop + lineHeight > input.scrollTop + input.clientHeight) {
@@ -726,11 +837,10 @@
 
   function setQuietValue(next, cursor) {
     input.value = next;
+    quietAnchor = null;
     quietCursor = Math.max(0, Math.min(cursor, next.length));
-    // Keep native selection in sync (harmless without focus, useful if focus fallback)
     try { input.setSelectionRange(quietCursor, quietCursor); } catch { /* ignore */ }
     input.dispatchEvent(new Event('input', { bubbles: true }));
-    // Grow textarea height like the normal input handler
     try {
       input.style.height = 'auto';
       input.style.height = Math.min(input.scrollHeight, 140) + 'px';
@@ -741,80 +851,163 @@
   }
 
   function insertQuietText(chunk) {
-    if (!chunk) return;
+    if (chunk == null || chunk === '') return;
     const v = input.value || '';
-    const next = v.slice(0, quietCursor) + chunk + v.slice(quietCursor);
-    setQuietValue(next, quietCursor + chunk.length);
+    const { start, end } = quietSelRange();
+    const next = v.slice(0, start) + chunk + v.slice(end);
+    setQuietValue(next, start + chunk.length);
+  }
+
+  function deleteQuietSelectionOr(dir) {
+    const v = input.value || '';
+    if (hasQuietSel()) {
+      const { start, end } = quietSelRange();
+      setQuietValue(v.slice(0, start) + v.slice(end), start);
+      return;
+    }
+    if (dir === 'back' && quietCursor > 0) {
+      setQuietValue(v.slice(0, quietCursor - 1) + v.slice(quietCursor), quietCursor - 1);
+    } else if (dir === 'fwd' && quietCursor < v.length) {
+      setQuietValue(v.slice(0, quietCursor) + v.slice(quietCursor + 1), quietCursor);
+    } else {
+      updateQuietCaret();
+    }
+  }
+
+  function writeQuietClipboard(text) {
+    if (!text) return;
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(text).catch(() => {});
+    }
   }
 
   function applyQuietKey(msg) {
     if (!typingArmed || !msg || msg.type !== 'down') return;
-    const { key, text, ctrl, alt, meta } = msg;
+    const { key, text, ctrl, alt, meta, shift } = msg;
+    const mod = !!(ctrl || meta);
     const v = input.value || '';
+    const k = (key && key.length === 1) ? key.toLowerCase() : key;
 
     if (key === 'Escape') {
+      if (hasQuietSel()) {
+        clearQuietSel();
+        updateQuietCaret();
+        return;
+      }
       disarmTyping();
       return;
     }
-    if (key === 'Enter' && !ctrl && !alt && !meta) {
+    if (key === 'Enter' && !mod && !alt) {
       send();
       disarmTyping();
       return;
     }
+
+    // ---- Editing chords (Ctrl/Cmd) ----
+    if (mod && !alt) {
+      if (k === 'a') {
+        quietAnchor = 0;
+        quietCursor = v.length;
+        try { input.setSelectionRange(0, v.length); } catch { /* ignore */ }
+        updateQuietCaret();
+        return;
+      }
+      if (k === 'c') {
+        const { start, end } = quietSelRange();
+        if (end > start) writeQuietClipboard(v.slice(start, end));
+        return;
+      }
+      if (k === 'x') {
+        const { start, end } = quietSelRange();
+        if (end > start) {
+          writeQuietClipboard(v.slice(start, end));
+          setQuietValue(v.slice(0, start) + v.slice(end), start);
+        }
+        return;
+      }
+      if (k === 'v') {
+        if (navigator.clipboard && navigator.clipboard.readText) {
+          navigator.clipboard.readText().then((t) => {
+            if (!t || !typingArmed) return;
+            insertQuietText(t);
+          }).catch(() => {});
+        }
+        return;
+      }
+      if (k === 'z') {
+        // Match focused path: restore last question when the box is empty.
+        if (!v.trim()) restoreLastQuestion();
+        return;
+      }
+    }
+
     if (key === 'ArrowLeft') {
-      quietCursor = ctrl ? 0 : Math.max(0, quietCursor - 1);
-      updateQuietCaret();
+      let pos;
+      if (mod) pos = wordLeft(v, quietCursor);
+      else if (!shift && hasQuietSel()) pos = quietSelRange().start;
+      else pos = Math.max(0, quietCursor - 1);
+      setQuietCursor(pos, { extend: !!shift });
       return;
     }
     if (key === 'ArrowRight') {
-      quietCursor = ctrl ? v.length : Math.min(v.length, quietCursor + 1);
-      updateQuietCaret();
+      let pos;
+      if (mod) pos = wordRight(v, quietCursor);
+      else if (!shift && hasQuietSel()) pos = quietSelRange().end;
+      else pos = Math.min(v.length, quietCursor + 1);
+      setQuietCursor(pos, { extend: !!shift });
       return;
     }
-    if (key === 'Home' || (key === 'ArrowUp' && ctrl)) {
-      // start of current line
-      const lineStart = v.lastIndexOf('\n', Math.max(0, quietCursor - 1)) + 1;
-      quietCursor = lineStart;
-      updateQuietCaret();
+    if (key === 'ArrowUp') {
+      // Line up is hard without full layout; jump to line start (or doc start with Ctrl).
+      const pos = mod ? 0 : lineStartAt(v, quietCursor);
+      setQuietCursor(pos, { extend: !!shift });
       return;
     }
-    if (key === 'End' || (key === 'ArrowDown' && ctrl)) {
-      const nextNl = v.indexOf('\n', quietCursor);
-      quietCursor = nextNl === -1 ? v.length : nextNl;
-      updateQuietCaret();
+    if (key === 'ArrowDown') {
+      const pos = mod ? v.length : lineEndAt(v, quietCursor);
+      setQuietCursor(pos, { extend: !!shift });
+      return;
+    }
+    if (key === 'Home') {
+      const pos = mod ? 0 : lineStartAt(v, quietCursor);
+      setQuietCursor(pos, { extend: !!shift });
+      return;
+    }
+    if (key === 'End') {
+      const pos = mod ? v.length : lineEndAt(v, quietCursor);
+      setQuietCursor(pos, { extend: !!shift });
       return;
     }
     if (key === 'Backspace') {
-      if (ctrl) {
-        setQuietValue(v.slice(quietCursor), 0);
-      } else if (quietCursor > 0) {
-        setQuietValue(v.slice(0, quietCursor - 1) + v.slice(quietCursor), quietCursor - 1);
+      if (hasQuietSel()) {
+        deleteQuietSelectionOr('back');
+        return;
+      }
+      if (mod) {
+        const from = wordLeft(v, quietCursor);
+        setQuietValue(v.slice(0, from) + v.slice(quietCursor), from);
       } else {
-        updateQuietCaret();
+        deleteQuietSelectionOr('back');
       }
       return;
     }
     if (key === 'Delete') {
-      if (quietCursor < v.length) {
-        setQuietValue(v.slice(0, quietCursor) + v.slice(quietCursor + 1), quietCursor);
+      if (hasQuietSel()) {
+        deleteQuietSelectionOr('fwd');
+        return;
+      }
+      if (mod) {
+        const to = wordRight(v, quietCursor);
+        setQuietValue(v.slice(0, quietCursor) + v.slice(to), quietCursor);
       } else {
-        updateQuietCaret();
+        deleteQuietSelectionOr('fwd');
       }
       return;
     }
-    // Printable text
-    if (text && text.length && !ctrl && !alt && !meta) {
+    // Printable text (replaces selection if any)
+    if (text && text.length && !mod && !alt) {
       insertQuietText(text);
       return;
-    }
-    // Ctrl+V paste
-    if ((ctrl || meta) && (key === 'v' || key === 'V')) {
-      if (navigator.clipboard && navigator.clipboard.readText) {
-        navigator.clipboard.readText().then((t) => {
-          if (!t || !typingArmed) return;
-          insertQuietText(t);
-        }).catch(() => {});
-      }
     }
   }
 
@@ -827,6 +1020,7 @@
     input.tabIndex = -1; // never OS-focus the textarea
     try { input.blur(); } catch { /* ignore */ }
     quietCursor = (input.value || '').length;
+    quietAnchor = null;
     composer.classList.add('focused', 'quiet-typing');
     placeholder.classList.add('hidden');
     updateQuietCaret();
@@ -848,11 +1042,14 @@
     if (!typingArmed) {
       if (cue.quietTypeSync) try { cue.quietTypeSync(false); } catch { /* ignore */ }
       if (quietCaretEl) quietCaretEl.classList.add('hidden');
+      if (quietMirror) quietMirror.classList.remove('sel-visible');
       return;
     }
     typingArmed = false;
+    quietAnchor = null;
     composer.classList.remove('focused', 'quiet-typing');
     if (quietCaretEl) quietCaretEl.classList.add('hidden');
+    if (quietMirror) quietMirror.classList.remove('sel-visible');
     syncPlaceholder();
     if (cue.quietTypeSync) {
       try { cue.quietTypeSync(false); } catch { /* ignore */ }
@@ -900,6 +1097,7 @@
     
     input.value = '';
     quietCursor = 0;
+    quietAnchor = null;
     inputFromSTT = false;
     lastSTTValue = ''; // FIX #6: Clear tracked STT value
     userSpeechStart = null;

--- a/renderer/styles.css
+++ b/renderer/styles.css
@@ -75,20 +75,15 @@ html, body {
   overflow: hidden;
 }
 #toolbar, #panel-wrap, #settings-scrim, #onboard-scrim, #consent-scrim { pointer-events: auto; }
-<<<<<<< HEAD
 /* No -webkit-app-region: drag — Chromium's drag region activates the window and
    blurs the app underneath. Drag is handled in renderer.js via screen coords. */
-#panel-wrap, #panel, #messages, #action-row, #composer, #input, textarea, button, .act, .smart-pill, .more-btn, #send-btn, .s-close, .s-seg button, .ob-buttons button, .ob-ghost, .ob-primary {
-  -webkit-app-region: no-drag;
-}
-=======
-#toolbar { -webkit-app-region: drag; }   /* drag the top pill to move the window */
-/* Explicit no-drag on every toolbar control so clicks (esp. Quit) are not eaten by the drag region. */
+/* Explicit no-drag on toolbar controls so Quit / Hide / Stop clicks always register. */
 #toolbar button, #toolbar .tb-quit, #toolbar .tb-stop, #toolbar .tb-hide, #toolbar .tb-logo {
   -webkit-app-region: no-drag;
 }
-#panel-wrap, #panel, #messages, #action-row, #composer, #input, textarea, button, .act, .smart-pill, .more-btn, #send-btn, .s-close, .s-seg button, .ob-buttons button, .ob-ghost, .ob-primary { -webkit-app-region: no-drag; }
->>>>>>> 87146d9 (Wire the quit button so it actually exits)
+#panel-wrap, #panel, #messages, #action-row, #composer, #input, textarea, button, .act, .smart-pill, .more-btn, #send-btn, .s-close, .s-seg button, .ob-buttons button, .ob-ghost, .ob-primary {
+  -webkit-app-region: no-drag;
+}
 
 /* ============================ Toolbar pill ============================ */
 #toolbar {

--- a/renderer/styles.css
+++ b/renderer/styles.css
@@ -75,11 +75,20 @@ html, body {
   overflow: hidden;
 }
 #toolbar, #panel-wrap, #settings-scrim, #onboard-scrim, #consent-scrim { pointer-events: auto; }
+<<<<<<< HEAD
 /* No -webkit-app-region: drag — Chromium's drag region activates the window and
    blurs the app underneath. Drag is handled in renderer.js via screen coords. */
 #panel-wrap, #panel, #messages, #action-row, #composer, #input, textarea, button, .act, .smart-pill, .more-btn, #send-btn, .s-close, .s-seg button, .ob-buttons button, .ob-ghost, .ob-primary {
   -webkit-app-region: no-drag;
 }
+=======
+#toolbar { -webkit-app-region: drag; }   /* drag the top pill to move the window */
+/* Explicit no-drag on every toolbar control so clicks (esp. Quit) are not eaten by the drag region. */
+#toolbar button, #toolbar .tb-quit, #toolbar .tb-stop, #toolbar .tb-hide, #toolbar .tb-logo {
+  -webkit-app-region: no-drag;
+}
+#panel-wrap, #panel, #messages, #action-row, #composer, #input, textarea, button, .act, .smart-pill, .more-btn, #send-btn, .s-close, .s-seg button, .ob-buttons button, .ob-ghost, .ob-primary { -webkit-app-region: no-drag; }
+>>>>>>> 87146d9 (Wire the quit button so it actually exits)
 
 /* ============================ Toolbar pill ============================ */
 #toolbar {

--- a/renderer/styles.css
+++ b/renderer/styles.css
@@ -470,7 +470,8 @@ button:focus { outline: none; }
   border-color: var(--bd-strong);
   box-shadow: 0 0 0 3px rgba(60,131,245,0.15);
 }
-/* Hidden mirror used only for measuring caret x/y (same font metrics as #input). */
+/* Mirror measures caret x/y; when a range is selected it paints a highlight
+   over the real textarea text (color transparent, only .quiet-sel shows). */
 #quiet-caret-mirror {
   position: absolute;
   visibility: hidden;
@@ -481,6 +482,16 @@ button:focus { outline: none; }
   top: 0;
   left: 0;
   z-index: -1;
+  color: transparent;
+}
+#quiet-caret-mirror.sel-visible {
+  visibility: visible;
+  z-index: 2;
+}
+#quiet-caret-mirror .quiet-sel {
+  background: rgba(60, 131, 245, 0.38);
+  color: transparent;
+  border-radius: 2px;
 }
 #placeholder {
   position: absolute; inset: 0; pointer-events: none;

--- a/renderer/styles.css
+++ b/renderer/styles.css
@@ -29,11 +29,18 @@
 
 html, body {
   margin: 0;
+  width: 100%;
   height: 100%;
   background: transparent;               /* Electron transparent window */
   font-family: var(--font);
   -webkit-font-smoothing: antialiased;
-  overflow: hidden;
+  /* Lock the overlay shell — only intentional panes (#messages, settings,
+     textarea) may scroll. scrollIntoView / wheel used to shift the whole
+     window so only the drag pill stayed on screen. */
+  overflow: hidden !important;
+  overscroll-behavior: none;
+  position: fixed;
+  inset: 0;
   cursor: default;
   -webkit-user-select: none;
   user-select: none;
@@ -45,16 +52,34 @@ html, body {
 #app {
   position: relative;
   z-index: 2;
+  width: 100%;
   height: 100%;
+  max-height: 100%;
+  overflow: hidden;
   display: flex;
   flex-direction: column;
   align-items: center;
   padding-top: 14px;
   pointer-events: none;                  /* only the actual UI blocks; gaps pass through */
 }
+/* Toolbar stays pinned at the top of the overlay; panel scrolls internally only. */
+#toolbar {
+  flex-shrink: 0;
+  position: relative;
+  z-index: 5;
+}
+#panel-wrap {
+  flex: 0 1 auto;
+  min-height: 0;
+  max-height: calc(100% - 56px);
+  overflow: hidden;
+}
 #toolbar, #panel-wrap, #settings-scrim, #onboard-scrim, #consent-scrim { pointer-events: auto; }
-#toolbar { -webkit-app-region: drag; }   /* drag the top pill to move the window */
-#panel-wrap, #panel, #messages, #action-row, #composer, #input, textarea, button, .act, .smart-pill, .more-btn, #send-btn, .s-close, .s-seg button, .ob-buttons button, .ob-ghost, .ob-primary { -webkit-app-region: no-drag; }
+/* No -webkit-app-region: drag — Chromium's drag region activates the window and
+   blurs the app underneath. Drag is handled in renderer.js via screen coords. */
+#panel-wrap, #panel, #messages, #action-row, #composer, #input, textarea, button, .act, .smart-pill, .more-btn, #send-btn, .s-close, .s-seg button, .ob-buttons button, .ob-ghost, .ob-primary {
+  -webkit-app-region: no-drag;
+}
 
 /* ============================ Toolbar pill ============================ */
 #toolbar {
@@ -68,8 +93,10 @@ html, body {
   box-shadow: 0 8px 24px rgba(0,0,0,0.40), inset 0 1px 0 rgba(255,255,255,0.08);
   backdrop-filter: blur(24px) saturate(160%);
   -webkit-backdrop-filter: blur(24px) saturate(160%);
+  -webkit-app-region: no-drag;
+  user-select: none;
 }
-.drag-handle { -webkit-app-region: drag; }
+.drag-handle { -webkit-app-region: no-drag; }
 .drag-pill {
   display: inline-flex; align-items: center; gap: 6px;
   padding: 4px 8px; border-radius: var(--r-pill);
@@ -77,9 +104,16 @@ html, body {
   color: rgba(255,255,255,0.8);
   font-size: 12px; font-weight: 600; letter-spacing: 0.01em;
   cursor: grab;
-  -webkit-app-region: drag;
+  -webkit-app-region: no-drag;
+  touch-action: none;
 }
 .drag-pill:hover { background: rgba(255,255,255,0.10); }
+.drag-pill.dragging { cursor: grabbing; background: rgba(255,255,255,0.14); }
+/* Overlay controls never show a focus ring — they must not look or act focused. */
+button:focus, button:focus-visible, textarea:focus, input:focus, select:focus {
+  outline: none !important;
+  box-shadow: none;
+}
 .drag-dots {
   width: 14px; height: 10px;
   display: inline-block;
@@ -147,7 +181,11 @@ html, body {
 .mic-perm-actions button.dismiss:hover { background: rgba(255,255,255,0.10); color: var(--tx-2); }
 
 /* ============================ Panel ============================ */
-#panel-wrap { position: relative; margin-top: 12px; width: min(624px, 94vw); }
+#panel-wrap {
+  position: relative;
+  margin-top: 12px;
+  width: min(624px, 94vw);
+}
 button:focus { outline: none; }
 #live-dot {
   position: absolute; top: -3px; left: -5px; z-index: 4;
@@ -170,7 +208,14 @@ button:focus { outline: none; }
 #panel.collapsed { display: none; }
 
 /* ============================ Messages ============================ */
-#messages { display: flex; flex-direction: column; overflow-y: auto; max-height: 50vh; }
+#messages {
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+  overflow-x: hidden;
+  max-height: min(50vh, 280px);
+  overscroll-behavior: contain; /* don't chain-scroll the overlay window */
+}
 .user-bubble {
   align-self: flex-end;
   max-width: 75%;
@@ -397,6 +442,42 @@ button:focus { outline: none; }
 }
 #composer.focused { border-color: var(--bd-strong); box-shadow: 0 0 0 3px rgba(60,131,245,0.15); }
 #input-area { position: relative; min-height: 22px; }
+/* Fake caret — position is updated in JS to track the quiet-typing cursor. */
+#quiet-caret {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 2px;
+  height: 18px;
+  margin-top: 2px;
+  background: var(--accent);
+  border-radius: 1px;
+  animation: quietCaretBlink 1.05s step-end infinite;
+  pointer-events: none;
+  z-index: 3;
+  will-change: transform;
+}
+#quiet-caret.hidden { display: none; }
+@keyframes quietCaretBlink {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0; }
+}
+#composer.quiet-typing {
+  border-color: var(--bd-strong);
+  box-shadow: 0 0 0 3px rgba(60,131,245,0.15);
+}
+/* Hidden mirror used only for measuring caret x/y (same font metrics as #input). */
+#quiet-caret-mirror {
+  position: absolute;
+  visibility: hidden;
+  pointer-events: none;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+  top: 0;
+  left: 0;
+  z-index: -1;
+}
 #placeholder {
   position: absolute; inset: 0; pointer-events: none;
   color: var(--tx-mut); font-size: 15px; line-height: 22px;

--- a/src/no-activate.js
+++ b/src/no-activate.js
@@ -1,0 +1,102 @@
+// Keep the overlay from stealing OS focus during normal button/drag use,
+// while still allowing a real keyboard caret when the user clicks the
+// composer or opens Settings.
+//
+// Strategy (Electron-native only — no PowerShell / user32 hacks):
+//   - Default: setFocusable(false) so clicks on buttons don't take the
+//     keyboard from the app underneath.
+//   - Typing: setFocusable(true) + focus() SYNCHRONOUSLY on the user gesture
+//     (sendSync from renderer mousedown) so Windows grants foreground rights.
+//
+// The previous WS_EX_NOACTIVATE PowerShell path fought Electron's own style
+// bits and async unlock always lost the foreground lock, so keys never arrived.
+
+/**
+ * Wire a BrowserWindow for non-activating UI with opt-in typing.
+ * @param {Electron.BrowserWindow} win
+ */
+function installNoActivate(win) {
+  if (!win || win.isDestroyed()) return;
+
+  win.__cueAllowFocus = false;
+  try { win.setFocusable(false); } catch { /* ignore */ }
+
+  // Reject accidental activation unless typing/settings mode is armed.
+  win.on('focus', () => {
+    if (win.__cueAllowFocus) return;
+    try { if (typeof win.blur === 'function') win.blur(); } catch { /* ignore */ }
+    try { win.setFocusable(false); } catch { /* ignore */ }
+  });
+
+  // Prefer inactive show so mere "show" does not steal focus.
+  const originalShow = win.show.bind(win);
+  win.show = (...args) => {
+    if (win.__cueAllowFocus) return originalShow(...args);
+    try {
+      if (typeof win.showInactive === 'function') return win.showInactive();
+    } catch { /* fall through */ }
+    return originalShow(...args);
+  };
+
+  const lock = () => {
+    if (win.isDestroyed() || win.__cueAllowFocus) return;
+    try { win.setFocusable(false); } catch { /* ignore */ }
+  };
+
+  if (win.isVisible()) lock();
+  else win.once('ready-to-show', lock);
+  win.webContents.on('did-finish-load', lock);
+  win.on('show', lock);
+}
+
+/**
+ * Enable keyboard. MUST be called on the user input stack (sync IPC) so
+ * Windows allows SetForegroundWindow / focus.
+ */
+function allowActivate(win) {
+  if (!win || win.isDestroyed()) return false;
+  win.__cueAllowFocus = true;
+  try { win.setFocusable(true); } catch { /* ignore */ }
+  try {
+    if (!win.isVisible()) {
+      if (typeof win.showInactive === 'function') win.showInactive();
+      else win.show();
+    }
+  } catch { /* ignore */ }
+  try { win.moveTop(); } catch { /* ignore */ }
+  try { win.focus(); } catch { /* ignore */ }
+  try {
+    if (win.webContents && !win.webContents.isDestroyed()) {
+      win.webContents.focus();
+    }
+  } catch { /* ignore */ }
+  return true;
+}
+
+/** Disable keyboard again; return focus to whatever is underneath. */
+function restoreNoActivate(win) {
+  if (!win || win.isDestroyed()) return false;
+  win.__cueAllowFocus = false;
+  try {
+    if (win.webContents && !win.webContents.isDestroyed()) {
+      // leave webContents alone; blur the window
+    }
+  } catch { /* ignore */ }
+  try { if (typeof win.blur === 'function') win.blur(); } catch { /* ignore */ }
+  try { win.setFocusable(false); } catch { /* ignore */ }
+  return true;
+}
+
+// Stubs kept so older callers don't break
+function applyWindowsNoActivate() { return Promise.resolve(true); }
+function clearWindowsNoActivate() { return Promise.resolve(true); }
+function hwndFromNativeHandle() { return null; }
+
+module.exports = {
+  installNoActivate,
+  applyWindowsNoActivate,
+  clearWindowsNoActivate,
+  allowActivate,
+  restoreNoActivate,
+  hwndFromNativeHandle
+};

--- a/src/quiet-keyboard.js
+++ b/src/quiet-keyboard.js
@@ -93,12 +93,23 @@ public static class CueQuietKb {
       case 0x0D: return "Enter";
       case 0x1B: return "Escape";
       case 0x2E: return "Delete";
+      case 0x23: return "End";
+      case 0x24: return "Home";
       case 0x25: return "ArrowLeft";
       case 0x26: return "ArrowUp";
       case 0x27: return "ArrowRight";
       case 0x28: return "ArrowDown";
       default: return null;
     }
+  }
+
+  // Stable letter/digit tokens even with Ctrl/Alt held (ToUnicode returns
+  // control chars or nothing for Ctrl+A, so shortcuts never matched).
+  static string LetterOrDigit(uint vk) {
+    if (vk >= 0x41 && vk <= 0x5A) return ((char)(vk + 32)).ToString(); // a-z
+    if (vk >= 0x30 && vk <= 0x39) return ((char)vk).ToString();
+    if (vk >= 0x60 && vk <= 0x69) return ((char)('0' + (vk - 0x60))).ToString(); // numpad
+    return null;
   }
 
   static string ToChar(uint vk, uint scan) {
@@ -137,13 +148,19 @@ public static class CueQuietKb {
           string key = Named(vk);
           string text = "";
           if (key == null) {
-            if (down && !ctrl && !alt && !meta) {
+            string lod = LetterOrDigit(vk);
+            if (lod != null) {
+              key = lod;
+              // Printable glyph only without chord modifiers (Ctrl+A is not "a").
+              if (down && !ctrl && !alt && !meta) {
+                string ch = ToChar(vk, info.scanCode);
+                if (!string.IsNullOrEmpty(ch)) text = ch;
+              }
+            } else if (down && !ctrl && !alt && !meta) {
               string ch = ToChar(vk, info.scanCode);
               if (!string.IsNullOrEmpty(ch)) { text = ch; key = ch; }
             }
             if (key == null) key = "Vk" + vk;
-          } else if (key == null) {
-            key = "Vk" + vk;
           }
           string line = (down ? "D" : "U") + "|" + Clean(key) + "|" + Clean(text) + "|"
             + (ctrl ? "1" : "0") + "|" + (alt ? "1" : "0") + "|" + (shift ? "1" : "0") + "|"

--- a/src/quiet-keyboard.js
+++ b/src/quiet-keyboard.js
@@ -1,0 +1,270 @@
+// Quiet keyboard capture for the cue overlay (Windows).
+//
+// Arms a WH_KEYBOARD_LL hook in a hidden PowerShell process. Keys are swallowed
+// so the focused app underneath does not receive them, and are forwarded to cue
+// over stdout. The overlay stays non-focusable → no blur / focus events on the
+// app below (e.g. WindowFocusEvents test page).
+
+const { spawn } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const SCRIPT_PATH = path.join(os.tmpdir(), 'cue-quiet-keyboard.ps1');
+
+// Use a simple line protocol instead of JSON to avoid escaping hell across
+// JS → PowerShell → C# layers:
+//   R                          ready
+//   D|<key>|<text>|<c>|<a>|<s>|<m>|<vk>   key down
+//   U|<key>|<text>|<c>|<a>|<s>|<m>|<vk>   key up
+// key is a token (Enter, Backspace, a, A, ...); text is the typed character if any.
+const PS_SCRIPT = String.raw`
+$ErrorActionPreference = 'Stop'
+Add-Type @'
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Text;
+
+public static class CueQuietKb {
+  public const int WH_KEYBOARD_LL = 13;
+  public const int WM_KEYDOWN = 0x0100;
+  public const int WM_SYSKEYDOWN = 0x0104;
+  public const int WM_KEYUP = 0x0101;
+  public const int WM_SYSKEYUP = 0x0105;
+
+  public delegate IntPtr HookProc(int nCode, IntPtr wParam, IntPtr lParam);
+
+  [StructLayout(LayoutKind.Sequential)]
+  public struct KBDLLHOOKSTRUCT {
+    public uint vkCode;
+    public uint scanCode;
+    public uint flags;
+    public uint time;
+    public IntPtr dwExtraInfo;
+  }
+
+  [DllImport("user32.dll", SetLastError=true)]
+  public static extern IntPtr SetWindowsHookEx(int idHook, HookProc lpfn, IntPtr hMod, uint dwThreadId);
+  [DllImport("user32.dll", SetLastError=true)]
+  [return: MarshalAs(UnmanagedType.Bool)]
+  public static extern bool UnhookWindowsHookEx(IntPtr hhk);
+  [DllImport("user32.dll")]
+  public static extern IntPtr CallNextHookEx(IntPtr hhk, int nCode, IntPtr wParam, IntPtr lParam);
+  [DllImport("kernel32.dll", CharSet=CharSet.Auto)]
+  public static extern IntPtr GetModuleHandle(string lpModuleName);
+  [DllImport("user32.dll")]
+  public static extern short GetKeyState(int nVirtKey);
+  [DllImport("user32.dll")]
+  public static extern bool GetKeyboardState(byte[] lpKeyState);
+  [DllImport("user32.dll")]
+  public static extern int ToUnicode(uint wVirtKey, uint wScanCode, byte[] lpKeyState,
+    [Out, MarshalAs(UnmanagedType.LPWStr)] StringBuilder pwszBuff, int cchBuff, uint wFlags);
+  [DllImport("user32.dll")]
+  public static extern int GetMessage(out MSG lpMsg, IntPtr hWnd, uint wMsgFilterMin, uint wMsgFilterMax);
+  [DllImport("user32.dll")]
+  public static extern bool TranslateMessage(ref MSG lpMsg);
+  [DllImport("user32.dll")]
+  public static extern IntPtr DispatchMessage(ref MSG lpMsg);
+
+  [StructLayout(LayoutKind.Sequential)]
+  public struct MSG {
+    public IntPtr hwnd;
+    public uint message;
+    public IntPtr wParam;
+    public IntPtr lParam;
+    public uint time;
+    public int pt_x;
+    public int pt_y;
+  }
+
+  public static IntPtr Hook = IntPtr.Zero;
+  public static HookProc Proc = HookCallback;
+
+  static bool IsMod(uint vk) {
+    return vk == 0x10 || vk == 0x11 || vk == 0x12 || vk == 0x5B || vk == 0x5C
+      || vk == 0xA0 || vk == 0xA1 || vk == 0xA2 || vk == 0xA3 || vk == 0xA4 || vk == 0xA5;
+  }
+
+  static string Named(uint vk) {
+    switch (vk) {
+      case 0x08: return "Backspace";
+      case 0x09: return "Tab";
+      case 0x0D: return "Enter";
+      case 0x1B: return "Escape";
+      case 0x2E: return "Delete";
+      case 0x25: return "ArrowLeft";
+      case 0x26: return "ArrowUp";
+      case 0x27: return "ArrowRight";
+      case 0x28: return "ArrowDown";
+      default: return null;
+    }
+  }
+
+  static string ToChar(uint vk, uint scan) {
+    byte[] state = new byte[256];
+    GetKeyboardState(state);
+    state[0x10] = (byte)((GetKeyState(0x10) & 0x8000) != 0 ? 0x80 : 0);
+    state[0x11] = (byte)((GetKeyState(0x11) & 0x8000) != 0 ? 0x80 : 0);
+    state[0x12] = (byte)((GetKeyState(0x12) & 0x8000) != 0 ? 0x80 : 0);
+    state[0x14] = (byte)((GetKeyState(0x14) & 0x0001) != 0 ? 0x01 : 0);
+    StringBuilder sb = new StringBuilder(8);
+    int rc = ToUnicode(vk, scan, state, sb, sb.Capacity, 0);
+    if (rc == 1) return sb.ToString();
+    // dead key / multi: ignore
+    return null;
+  }
+
+  static string Clean(string s) {
+    if (string.IsNullOrEmpty(s)) return "";
+    // pipe is our delimiter — strip it
+    return s.Replace("|", "").Replace("\r", "").Replace("\n", "");
+  }
+
+  public static IntPtr HookCallback(int nCode, IntPtr wParam, IntPtr lParam) {
+    if (nCode >= 0) {
+      int msg = wParam.ToInt32();
+      bool down = msg == WM_KEYDOWN || msg == WM_SYSKEYDOWN;
+      bool up = msg == WM_KEYUP || msg == WM_SYSKEYUP;
+      if (down || up) {
+        KBDLLHOOKSTRUCT info = (KBDLLHOOKSTRUCT)Marshal.PtrToStructure(lParam, typeof(KBDLLHOOKSTRUCT));
+        uint vk = info.vkCode;
+        if (!IsMod(vk)) {
+          bool ctrl = (GetKeyState(0x11) & 0x8000) != 0;
+          bool alt = (GetKeyState(0x12) & 0x8000) != 0;
+          bool shift = (GetKeyState(0x10) & 0x8000) != 0;
+          bool meta = (GetKeyState(0x5B) & 0x8000) != 0 || (GetKeyState(0x5C) & 0x8000) != 0;
+          string key = Named(vk);
+          string text = "";
+          if (key == null) {
+            if (down && !ctrl && !alt && !meta) {
+              string ch = ToChar(vk, info.scanCode);
+              if (!string.IsNullOrEmpty(ch)) { text = ch; key = ch; }
+            }
+            if (key == null) key = "Vk" + vk;
+          } else if (key == null) {
+            key = "Vk" + vk;
+          }
+          string line = (down ? "D" : "U") + "|" + Clean(key) + "|" + Clean(text) + "|"
+            + (ctrl ? "1" : "0") + "|" + (alt ? "1" : "0") + "|" + (shift ? "1" : "0") + "|"
+            + (meta ? "1" : "0") + "|" + vk;
+          Console.WriteLine(line);
+          Console.Out.Flush();
+          return (IntPtr)1; // swallow
+        }
+      }
+    }
+    return CallNextHookEx(Hook, nCode, wParam, lParam);
+  }
+
+  public static void Run() {
+    Process cur = Process.GetCurrentProcess();
+    ProcessModule mod = cur.MainModule;
+    Hook = SetWindowsHookEx(WH_KEYBOARD_LL, Proc, GetModuleHandle(mod.ModuleName), 0);
+    if (Hook == IntPtr.Zero) {
+      Console.WriteLine("E|SetWindowsHookEx failed");
+      return;
+    }
+    Console.WriteLine("R");
+    Console.Out.Flush();
+    MSG msg;
+    while (GetMessage(out msg, IntPtr.Zero, 0, 0) > 0) {
+      TranslateMessage(ref msg);
+      DispatchMessage(ref msg);
+    }
+    UnhookWindowsHookEx(Hook);
+  }
+}
+'@
+[CueQuietKb]::Run()
+`;
+
+let child = null;
+let buffer = '';
+let keyHandler = null;
+
+function startQuietKeyboard(onEvent) {
+  if (process.platform !== 'win32') {
+    return { ok: false, error: 'quiet-keyboard is Windows-only' };
+  }
+  stopQuietKeyboard();
+  keyHandler = onEvent;
+  try {
+    fs.writeFileSync(SCRIPT_PATH, PS_SCRIPT, 'utf8');
+  } catch (err) {
+    return { ok: false, error: err.message };
+  }
+
+  try {
+    child = spawn(
+      'powershell.exe',
+      ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', SCRIPT_PATH],
+      { windowsHide: true, stdio: ['ignore', 'pipe', 'pipe'] }
+    );
+  } catch (err) {
+    child = null;
+    return { ok: false, error: err.message };
+  }
+
+  child.stdout.setEncoding('utf8');
+  child.stdout.on('data', (chunk) => {
+    buffer += chunk;
+    let idx;
+    while ((idx = buffer.indexOf('\n')) >= 0) {
+      const line = buffer.slice(0, idx).replace(/\r$/, '');
+      buffer = buffer.slice(idx + 1);
+      if (!line) continue;
+      if (line === 'R') continue;
+      if (line.startsWith('E|')) {
+        console.log('[quiet-keyboard]', line.slice(2));
+        continue;
+      }
+      const parts = line.split('|');
+      if (parts.length < 8) continue;
+      const msg = {
+        type: parts[0] === 'D' ? 'down' : 'up',
+        key: parts[1],
+        text: parts[2],
+        ctrl: parts[3] === '1',
+        alt: parts[4] === '1',
+        shift: parts[5] === '1',
+        meta: parts[6] === '1',
+        vk: Number(parts[7]) || 0
+      };
+      if (typeof keyHandler === 'function') {
+        try { keyHandler(msg); } catch { /* ignore */ }
+      }
+    }
+  });
+
+  child.stderr.on('data', (c) => console.log('[quiet-keyboard:err]', String(c).slice(0, 300)));
+  child.on('exit', (code) => {
+    console.log('[quiet-keyboard] exit', code);
+    child = null;
+  });
+  child.on('error', (err) => {
+    console.log('[quiet-keyboard] error', err.message);
+    child = null;
+  });
+
+  return { ok: true };
+}
+
+function stopQuietKeyboard() {
+  keyHandler = null;
+  buffer = '';
+  if (child && !child.killed) {
+    try { child.kill(); } catch { /* ignore */ }
+  }
+  child = null;
+}
+
+function isQuietKeyboardActive() {
+  return !!(child && !child.killed);
+}
+
+module.exports = {
+  startQuietKeyboard,
+  stopQuietKeyboard,
+  isQuietKeyboardActive
+};


### PR DESCRIPTION
## Stack (gh stack)

Local stack (bottom → top):

```
main
 └── overlay/no-activate-focus   → PR #44
      └── feat/quiet-kbd-shortcuts → PR #48 (this)
```

Managed with `gh stack` (`init` + `link`).  
**Merge #44 first**, then this.

> GitHub native Stacks UI is **not enabled** on this repository, and cross-fork base retargeting to `overlay/no-activate-focus` is not possible without push access to the upstream. Both PRs currently target `main`; this PR includes #44’s commits plus one new one.

**Review only the top commit:** `b0d07aa` — Add Ctrl/Cmd editing shortcuts to quiet typing

## Summary
Quiet typing ignored Ctrl+A and friends: the low-level hook only named letter keys when no modifiers were held (`Vk65` instead of `a`).

## Changes (this layer only)
- **Hook** (`src/quiet-keyboard.js`): stable `a`–`z` / digit tokens under Ctrl/Alt/Meta; name Home/End
- **Composer**: selection + **Ctrl/Cmd+A C X V Z**, word nav/delete, shift-extend
- **Styles**: selection highlight on quiet caret mirror

## Test plan
- [ ] Arm quiet typing on Windows → Ctrl+A selects all
- [ ] Ctrl+C / X / V work
- [ ] Shift+arrows, Ctrl+←/→, Ctrl+Backspace
- [ ] App underneath does not blur