### PR TITLE
Default to gemma-4-31b-it for chat and large-v3 for local STT

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,8 @@
       "dependencies": {
         "@anthropic-ai/sdk": "^0.32.1",
         "@google/genai": "^2.12.0",
+        "@grpc/grpc-js": "^1.14.4",
+        "@grpc/proto-loader": "^0.8.1",
         "lucide-static": "^0.468.0",
         "mammoth": "^1.8.0",
         "openai": "^4.73.0",
@@ -541,6 +543,37 @@
         }
       }
     },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
+      "integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.8.0",
+        "@js-sdsl/ordered-map": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=12.10.0"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.1.tgz",
+      "integrity": "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.5.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/@isaacs/fs-minipass": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
@@ -552,6 +585,16 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@js-sdsl/ordered-map": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+      "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
       }
     },
     "node_modules/@malept/flatpak-bundler": {
@@ -921,7 +964,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -930,7 +972,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -1501,7 +1542,6 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "dev": true,
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.1",
@@ -1527,7 +1567,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -1538,8 +1577,7 @@
     "node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -2109,8 +2147,7 @@
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
@@ -2189,7 +2226,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -2494,7 +2530,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
       }
@@ -2871,7 +2906,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -3066,6 +3100,12 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
       "license": "MIT"
     },
     "node_modules/long": {
@@ -3899,7 +3939,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4179,7 +4218,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -4193,7 +4231,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -4559,7 +4596,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -4612,7 +4648,6 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       }
@@ -4628,7 +4663,6 @@
       "version": "17.7.3",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
       "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
-      "dev": true,
       "dependencies": {
         "cliui": "^8.0.1",
         "escalade": "^3.1.1",
@@ -4646,7 +4680,6 @@
       "version": "21.1.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "dev": true,
       "engines": {
         "node": ">=12"
       }

--- a/package.json
+++ b/package.json
@@ -40,6 +40,8 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.32.1",
     "@google/genai": "^2.12.0",
+    "@grpc/grpc-js": "^1.14.4",
+    "@grpc/proto-loader": "^0.8.1",
     "lucide-static": "^0.468.0",
     "mammoth": "^1.8.0",
     "openai": "^4.73.0",

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -172,8 +172,12 @@
           <button data-stt-provider="deepgram">Deepgram</button>
           <button data-stt-provider="openai">OpenAI</button>
           <button data-stt-provider="gemini">Gemini</button>
+          <button data-stt-provider="nvidia">NVIDIA</button>
         </div>
         <div class="s-note">Local mode keeps microphone and meeting audio on this computer. It never silently falls back to a cloud transcription provider.</div>
+        <div class="s-note">NVIDIA mode transcribes with the hosted whisper-large-v3 NIM on NVIDIA's cloud GPUs &mdash; large-v3 accuracy without the slow local CPU inference. Requires an NVIDIA API key plus the function-id from the model's API tab on build.nvidia.com.</div>
+        <div class="s-field"><span>NVIDIA API key</span><input id="key-nvidia" type="password" placeholder="nvapi-..." autocomplete="off" /></div>
+        <div class="s-field"><span>NVIDIA function-id</span><input id="nvidia-function-id" type="text" placeholder="from build.nvidia.com API tab" autocomplete="off" /></div>
 
         <div class="whisper-card">
           <div class="whisper-runtime-row">

--- a/renderer/renderer.js
+++ b/renderer/renderer.js
@@ -1269,6 +1269,8 @@
     document.querySelectorAll('#minimax-region-seg button').forEach((b) => b.classList.toggle('on', b.dataset.region === (settings.minimaxRegion || 'global_en')));
     $('#key-azure').value = settings.apiKeys.azure || '';
     $('#azure-endpoint').value = settings.azureEndpoint || '';
+    $('#key-nvidia').value = settings.apiKeys.nvidia || '';
+    $('#nvidia-function-id').value = settings.nvidiaFunctionId || '';
     const m = settings.models[settings.provider] || { fast: '', smart: '' };
     $('#model-fast').value = m.fast; $('#model-smart').value = m.smart;
     fillAppLinkCallers();
@@ -1351,12 +1353,12 @@
 
   function statusText() {
     const k = settings.apiKeys;
-    const labels = { openai: 'OpenAI', anthropic: 'Anthropic', gemini: 'Gemini', deepgram: 'Deepgram', custom: 'Custom', ollama: 'Ollama', groq: 'Groq', minimax: 'MiniMax', azure: 'Azure AI Foundry' };
+    const labels = { openai: 'OpenAI', anthropic: 'Anthropic', gemini: 'Gemini', deepgram: 'Deepgram', custom: 'Custom', ollama: 'Ollama', groq: 'Groq', minimax: 'MiniMax', azure: 'Azure AI Foundry', nvidia: 'NVIDIA' };
     const has = Object.keys(labels).filter((p) => k[p]).map((p) => labels[p]);
     // 'auto' walks the same fallback chain src/stt.js builds; an explicit choice
     // is reported as-is so the status line matches what will actually be used.
     const selectedSttProvider = settings.sttProvider || 'auto';
-    const automaticStt = k.deepgram ? 'Deepgram (streaming)' : (k.openai ? 'OpenAI Realtime' : (k.groq ? 'Groq Whisper' : (k.gemini ? 'Gemini (batch)' : 'none')));
+    const automaticStt = k.deepgram ? 'Deepgram (streaming)' : (k.openai ? 'OpenAI Realtime' : (k.groq ? 'Groq Whisper' : (k.gemini ? 'Gemini (batch)' : (k.nvidia && settings.nvidiaFunctionId ? 'NVIDIA Whisper (batch)' : 'none'))));
     const stt = selectedSttProvider === 'auto' ? automaticStt : selectedSttProvider;
     const ready = [
       settings.resumeText ? '✓ resume' : null,
@@ -1542,6 +1544,8 @@
     settings.apiKeys.minimax = $('#key-minimax').value.trim();
     settings.apiKeys.azure = $('#key-azure').value.trim();
     settings.azureEndpoint = $('#azure-endpoint').value.trim();
+    settings.apiKeys.nvidia = $('#key-nvidia').value.trim();
+    settings.nvidiaFunctionId = $('#nvidia-function-id').value.trim();
     if (!settings.models[settings.provider]) settings.models[settings.provider] = {};
     settings.models[settings.provider].fast = $('#model-fast').value.trim();
     settings.models[settings.provider].smart = $('#model-smart').value.trim();

--- a/src/llm.js
+++ b/src/llm.js
@@ -6,10 +6,14 @@ const { createCompatibleClientOptions } = require('./openai-compatible');
 const CUSTOM_PROVIDER = 'custom';
 // gemini-2.0-flash was Google's default here until it was deprecated (Feb 2026)
 // and fully retired (Mar 3 2026) — every request against it now 404s with a
-// generic "exception parsing response" body. gemini-2.5-flash is the model
-// Google's own SDK examples standardize on and is documented as free-tier
-// available, so it is the single default used everywhere in this file.
-const CURRENT_GEMINI_DEFAULT = 'gemini-2.5-flash';
+// generic "exception parsing response" body. gemma-4-31b-it is Google's
+// current flagship Gemma model (released Apr 2026) and is the single default
+// used everywhere in this file.
+const CURRENT_GEMINI_DEFAULT = 'gemma-4-31b-it';
+// gemma-4-31b-it (the dense flagship Gemma model) does not accept audio input —
+// Google's model card documents audio support only on the smaller E2B/E4B/12B
+// Gemma variants. stt.js/stt-streaming.js transcribe with this model instead.
+const CURRENT_GEMINI_AUDIO_MODEL = 'gemini-2.5-flash';
 const DEFAULT_MODELS = {
   openai: 'gpt-4o-mini',
   anthropic: 'claude-3-5-haiku-latest',
@@ -356,4 +360,4 @@ function createLLM(settings) {
   };
 }
 
-module.exports = { createLLM, formatProviderErrorMessage, isQuotaError, CURRENT_GEMINI_DEFAULT };
+module.exports = { createLLM, formatProviderErrorMessage, isQuotaError, CURRENT_GEMINI_DEFAULT, CURRENT_GEMINI_AUDIO_MODEL };

--- a/src/riva-proto/riva/proto/riva_asr.proto
+++ b/src/riva-proto/riva/proto/riva_asr.proto
@@ -1,0 +1,451 @@
+// SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+// Copyright 2019 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+package nvidia.riva.asr;
+
+option cc_enable_arenas = true;
+option go_package = "nvidia.com/riva_speech";
+
+import "riva/proto/riva_audio.proto";
+import "riva/proto/riva_common.proto";
+
+/*
+ * The RivaSpeechRecognition service provides two mechanisms for converting
+ * speech to text.
+ */
+service RivaSpeechRecognition {
+  // Recognize expects a RecognizeRequest and returns a RecognizeResponse. This
+  // request will block until the audio is uploaded, processed, and a transcript
+  // is returned.
+  rpc Recognize(RecognizeRequest) returns (RecognizeResponse) {}
+  // StreamingRecognize is a non-blocking API call that allows audio data to be
+  // fed to the server in chunks as it becomes available. Depending on the
+  // configuration in the StreamingRecognizeRequest, intermediate results can be
+  // sent back to the client. Recognition ends when the stream is closed by the
+  // client.
+  rpc StreamingRecognize(stream StreamingRecognizeRequest)
+      returns (stream StreamingRecognizeResponse) {}
+
+  // Enables clients to request the configuration of the current ASR service, or
+  // a specific model within the service.
+  rpc GetRivaSpeechRecognitionConfig(RivaSpeechRecognitionConfigRequest)
+      returns (RivaSpeechRecognitionConfigResponse) {}
+}
+
+/*
+ * RivaSpeechRecognitionConfigRequest
+ */
+
+message RivaSpeechRecognitionConfigRequest {
+  // If model is specified only return config for model, otherwise return all
+  // configs.
+  string model_name = 1;
+}
+
+message RivaSpeechRecognitionConfigResponse {
+  message Config {
+    string model_name = 1;
+    map<string, string> parameters = 2;
+  }
+
+  repeated Config model_config = 1;
+}
+
+/*
+ * RecognizeRequest is used for batch processing of a single audio recording.
+ */
+message RecognizeRequest {
+  // Provides information to recognizer that specifies how to process the
+  // request.
+  RecognitionConfig config = 1;
+  // The raw audio data to be processed. The audio bytes must be encoded as
+  // specified in `RecognitionConfig`.
+  bytes audio = 2;
+
+  // The ID to be associated with the request. If provided, this will be
+  // returned in the corresponding response.
+  RequestId id = 100;
+}
+
+/*
+ * A StreamingRecognizeRequest is used to configure and stream audio content to
+ * the Riva ASR Service. The first message sent must include only a
+ * StreamingRecognitionConfig. Subsequent messages sent in the stream must
+ * contain only raw bytes of the audio to be recognized.
+ */
+message StreamingRecognizeRequest {
+  // The streaming request, which is either a streaming config or audio content.
+  oneof streaming_request {
+    // Provides information to the recognizer that specifies how to process the
+    // request. The first `StreamingRecognizeRequest` message must contain a
+    // `streaming_config`  message.
+    StreamingRecognitionConfig streaming_config = 1;
+    // The audio data to be recognized. Sequential chunks of audio data are sent
+    // in sequential `StreamingRecognizeRequest` messages. The first
+    // `StreamingRecognizeRequest` message must not contain `audio` data
+    // and all subsequent `StreamingRecognizeRequest` messages must contain
+    // `audio` data. The audio bytes must be encoded as specified in
+    // `RecognitionConfig`.
+    bytes audio_content = 2;
+  }
+
+  // Per-chunk runtime configuration passed alongside audio_content messages.
+  // This is an OPTIONAL parameter which should be used when client needs to 
+  // tune server configuration during an ongoing session.
+  // Supported keys:
+  //   "force_eou" = "true" : Forces an immediate end-of-utterance for the
+  //   current stream, emitting a final transcript without ending the stream.
+  //   Unlike closing the stream (is_last), the stream remains open and
+  //   subsequent audio continues as a new utterance. Only supported for
+  //   cache-aware RNNT models.
+  map<string, string> runtime_config = 3;
+
+  // The ID to be associated with the request. If provided, this will be
+  // returned in the corresponding responses.
+  RequestId id = 100;
+}
+
+/*
+ * EndpointingConfig is used for configuring different fields related to start
+ * or end of utterance
+ */
+message EndpointingConfig {
+  // `start_history` is the size of the window, in milliseconds, used to
+  // detect start of utterance.
+  // `start_threshold` is the percentage threshold used to detect start of
+  // utterance. (0.0 to 1.0)
+  // If `start_threshold` of `start_history` ms of the acoustic model output
+  // have non-blank tokens, start of utterance is detected.
+  optional int32 start_history = 1;
+  optional float start_threshold = 2;
+
+  // `stop_history` is the size of the window, in milliseconds, used to
+  // detect end of utterance.
+  // `stop_threshold` is the percentage threshold used to detect end of
+  // utterance. (0.0 to 1.0)
+  // If `stop_threshold` of `stop_history` ms of the acoustic model output have
+  // non-blank tokens, end of utterance is detected and decoder will be reset.
+  optional int32 stop_history = 3;
+  optional float stop_threshold = 4;
+
+  // `stop_history_eou` and `stop_threshold_eou` are used for 2-pass end of utterance.
+  // `stop_history_eou` is the size of the window, in milliseconds, used to
+  // trigger 1st pass of end of utterance and generate a partial transcript
+  // with stability of 1. (stop_history_eou < stop_history)
+  // `stop_threshold_eou` is the percentage threshold used to trigger 1st
+  // pass of end of utterance. (0.0 to 1.0)
+  // If `stop_threshold_eou` of `stop_history_eou` ms of the acoustic model
+  // output have non-blank tokens, 1st pass of end of utterance is triggered.
+  optional int32 stop_history_eou = 5;
+  optional float stop_threshold_eou = 6;
+}
+
+// Provides information to the recognizer that specifies how to process the
+// request
+message RecognitionConfig {
+  // The encoding of the audio data sent in the request.
+  //
+  // All encodings support only 1 channel (mono) audio.
+  AudioEncoding encoding = 1;
+
+  //  The sample rate in hertz (Hz) of the audio data sent in the
+  // `RecognizeRequest` or `StreamingRecognizeRequest` messages.
+  //  The Riva server will automatically down-sample/up-sample the audio to
+  //  match the ASR acoustic model sample rate. The sample rate value below 8kHz
+  //  will not produce any meaningful output.
+  int32 sample_rate_hertz = 2;
+
+  // Required. The language of the supplied audio as a
+  // [BCP-47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt) language tag.
+  // Example: "en-US".
+  string language_code = 3;
+
+  // Maximum number of recognition hypotheses to be returned.
+  // Specifically, the maximum number of `SpeechRecognizeAlternative` messages
+  // within each `SpeechRecognizeResult`.
+  // The server may return fewer than `max_alternatives`.
+  // If omitted, will return a maximum of one.
+  int32 max_alternatives = 4;
+
+  // A custom field that enables profanity filtering for the generated
+  // transcripts. If set to 'true', the server filters out profanities,
+  // replacing all but the initial character in each filtered word with
+  // asterisks. For example, "x**". If set to `false` or omitted, profanities
+  // will not be filtered out. The default is `false`.
+  bool profanity_filter = 5;
+
+  // Array of SpeechContext.
+  // A means to provide context to assist the speech recognition. For more
+  // information, see SpeechContext section
+  repeated SpeechContext speech_contexts = 6;
+
+  // The number of channels in the input audio data.
+  // If `0` or omitted, defaults to one channel (mono).
+  // Note: Only single channel audio input is supported as of now.
+  int32 audio_channel_count = 7;
+
+  // If `true`, the top result includes a list of words and the start and end
+  // time offsets (timestamps), and confidence scores for those words. If
+  // `false`, no word-level time offset information is returned. The default
+  // is `false`.
+  bool enable_word_time_offsets = 8;
+
+  // If 'true', adds punctuation to recognition result hypotheses. The
+  // default 'false' value does not add punctuation to result hypotheses.
+  bool enable_automatic_punctuation = 11;
+
+  // This needs to be set to `true` explicitly and `audio_channel_count` > 1
+  // to get each channel recognized separately. The recognition result will
+  // contain a `channel_tag` field to state which channel that result belongs
+  // to. If this is not true, we will only recognize the first channel. The
+  // request is billed cumulatively for all channels recognized:
+  // `audio_channel_count` multiplied by the length of the audio.
+  // Note: This field is not yet supported.
+  bool enable_separate_recognition_per_channel = 12;
+
+  // Which model to select for the given request.
+  // If empty, Riva will select the right model based on the other
+  // RecognitionConfig parameters. The model should correspond to the name
+  // passed to `riva-build` with the `--name` argument
+  string model = 13;
+
+  // The verbatim_transcripts flag enables or disable inverse text
+  // normalization. 'true' returns exactly what was said, with no
+  // denormalization. 'false' applies inverse text normalization, also this is
+  // the default
+  bool verbatim_transcripts = 14;
+
+  // Config to enable speaker diarization and set additional
+  // parameters. For non-streaming requests, the diarization results will be
+  // provided only in the top alternative of the FINAL SpeechRecognitionResult.
+  SpeakerDiarizationConfig diarization_config = 19;
+
+  // Custom fields for passing request-level
+  // configuration options to plugins used in the
+  // model pipeline.
+  map<string, string> custom_configuration = 24;
+
+  // Config for tuning start or end of utterance parameters.
+  // If empty, Riva will use default values or custom values if specified in riva-build arguments.
+  optional EndpointingConfig endpointing_config = 25;
+}
+
+// Provides information to the recognizer that specifies how to process the
+// request
+message StreamingRecognitionConfig {
+  // Provides information to the recognizer that specifies how to process the
+  // request
+  RecognitionConfig config = 1;
+
+  // If `true`, interim results (tentative hypotheses) may be
+  // returned as they become available (these interim results are indicated with
+  // the `is_final=false` flag).
+  // If `false` or omitted, only `is_final=true` result(s) are returned.
+  bool interim_results = 2;
+}
+
+// Config to enable speaker diarization.
+message SpeakerDiarizationConfig {
+  // If 'true', enables speaker detection for each recognized word in
+  // the top alternative of the recognition result using a speaker_tag provided
+  // in the WordInfo.
+  bool enable_speaker_diarization = 1;
+
+  // Maximum number of speakers in the conversation. This gives flexibility by
+  // allowing the system to automatically determine the correct number of
+  // speakers. If not set, the default value is 8.
+  int32 max_speaker_count = 2;
+}
+
+// Provides "hints" to the speech recognizer to favor specific words and phrases
+// in the results.
+message SpeechContext {
+  // A list of strings containing words and phrases "hints" so that
+  // the speech recognition is more likely to recognize them. This can be used
+  // to improve the accuracy for specific words and phrases, for example, if
+  // specific commands are typically spoken by the user. This can also be used
+  // to add additional words to the vocabulary of the recognizer.
+  repeated string phrases = 1;
+
+  // Hint Boost. Positive value will increase the probability that a specific
+  // phrase will be recognized over other similar sounding phrases. The higher
+  // the boost, the higher the chance of false positive recognition as well.
+  // Though `boost` can accept a wide range of positive values, most use cases
+  // are best served with values between 0 and 20. We recommend using a binary
+  // search approach to finding the optimal value for your use case.
+  float boost = 4;
+}
+
+// The only message returned to the client by the `Recognize` method. It
+// contains the result as zero or more sequential `SpeechRecognitionResult`
+// messages.
+message RecognizeResponse {
+  // Sequential list of transcription results corresponding to
+  // sequential portions of audio. Currently only returns one transcript.
+  repeated SpeechRecognitionResult results = 1;
+
+  // The ID associated with the request
+  RequestId id = 100;
+}
+
+// A speech recognition result corresponding to the latest transcript
+message SpeechRecognitionResult {
+  // May contain one or more recognition hypotheses (up to the
+  // maximum specified in `max_alternatives`).
+  // These alternatives are ordered in terms of accuracy, with the top (first)
+  // alternative being the most probable, as ranked by the recognizer.
+  repeated SpeechRecognitionAlternative alternatives = 1;
+
+  // For multi-channel audio, this is the channel number corresponding to the
+  // recognized result for the audio from that channel.
+  // For audio_channel_count = N, its output values can range from '1' to 'N'.
+  int32 channel_tag = 2;
+
+  // Length of audio processed so far in seconds
+  float audio_processed = 3;
+}
+
+// Alternative hypotheses (a.k.a. n-best list).
+message SpeechRecognitionAlternative {
+  // Transcript text representing the words that the user spoke.
+  string transcript = 1;
+
+  // The confidence estimate. A higher number indicates an estimated greater
+  // likelihood that the recognized word is correct. This field is set only for
+  // a non-streaming result or, for a streaming result where is_final=true.
+  // This field is not guaranteed to be accurate and users should not rely on
+  // it to be always provided. Although confidence can currently be roughly
+  // interpreted as a natural-log probability, the estimate computation varies
+  // with difference configurations, and is subject to change. The default of
+  // 0.0 is a sentinel value indicating confidence was not set.
+  float confidence = 2;
+
+  // A list of word-specific information for each recognized word. Only
+  // populated if is_final=true
+  repeated WordInfo words = 3;
+
+  // List of language codes detected in the transcript.
+  repeated string language_code = 4;
+}
+
+// Word-specific information for recognized words.
+message WordInfo {
+  // Time offset relative to the beginning of the audio in ms
+  // and corresponding to the start of the spoken word.
+  // This field is only set if `enable_word_time_offsets=true` and only
+  // in the top hypothesis.
+  int32 start_time = 1;
+
+  // Time offset relative to the beginning of the audio in ms
+  // and corresponding to the end of the spoken word.
+  // This field is only set if `enable_word_time_offsets=true` and only
+  // in the top hypothesis.
+  int32 end_time = 2;
+
+  // The word corresponding to this set of information.
+  string word = 3;
+
+  // The confidence estimate. A higher number indicates an estimated greater
+  // likelihood that the recognized word is correct. This field is set only for
+  // a non-streaming result or, for a streaming result where is_final=true.
+  // This field is not guaranteed to be accurate and users should not rely on
+  // it to be always provided. Although confidence can currently be roughly
+  // interpreted as a natural-log probability, the estimate computation varies
+  // with difference configurations, and is subject to change. The default of
+  // 0.0 is a sentinel value indicating confidence was not set.
+  float confidence = 4;
+
+  // Output only. A distinct integer value is assigned for every speaker within
+  // the audio. This field specifies which one of those speakers was detected to
+  // have spoken this word. Value ranges from '1' to diarization_speaker_count.
+  // speaker_tag is set if enable_speaker_diarization = 'true' and only in the
+  // top alternative.
+  int32 speaker_tag = 5;
+
+  // The language code of the word.
+  string language_code = 6;
+}
+
+// `StreamingRecognizeResponse` is the only message returned to the client by
+// `StreamingRecognize`. A series of zero or more `StreamingRecognizeResponse`
+// messages are streamed back to the client.
+//
+// Here are few examples of `StreamingRecognizeResponse`s
+//
+// 1. results { alternatives { transcript: "tube" } stability: 0.01 }
+//
+// 2. results { alternatives { transcript: "to be a" } stability: 0.01 }
+//
+// 3. results { alternatives { transcript: "to be or not to be"
+//                             confidence: 0.92 }
+//              alternatives { transcript: "to bee or not to bee" }
+//              is_final: true }
+//
+
+message StreamingRecognizeResponse {
+  // This repeated list contains the latest transcript(s) corresponding to
+  // audio currently being processed.
+  // Currently one result is returned, where each result can have multiple
+  // alternatives
+  repeated StreamingRecognitionResult results = 1;
+
+  // The ID associated with the request
+  RequestId id = 100;
+}
+
+message PipelineStates {
+  // Neural VAD probabilities
+  repeated float vad_probabilities = 1;
+}
+
+// A streaming speech recognition result corresponding to a portion of the audio
+// that is currently being processed.
+message StreamingRecognitionResult {
+  // May contain one or more recognition hypotheses (up to the
+  // maximum specified in `max_alternatives`).
+  // These alternatives are ordered in terms of accuracy, with the top (first)
+  // alternative being the most probable, as ranked by the recognizer.
+  repeated SpeechRecognitionAlternative alternatives = 1;
+
+  // If `false`, this `StreamingRecognitionResult` represents an
+  // interim result that may change. If `true`, this is the final time the
+  // speech service will return this particular `StreamingRecognitionResult`,
+  // the recognizer will not return any further hypotheses for this portion of
+  // the transcript and corresponding audio.
+  bool is_final = 2;
+
+  // An estimate of the likelihood that the recognizer will not
+  // change its guess about this interim result. Values range from 0.0
+  // (completely unstable) to 1.0 (completely stable).
+  // This field is only provided for interim results (`is_final=false`).
+  // The default of 0.0 is a sentinel value indicating `stability` was not set.
+  float stability = 3;
+
+  // For multi-channel audio, this is the channel number corresponding to the
+  // recognized result for the audio from that channel.
+  // For audio_channel_count = N, its output values can range from '1' to 'N'.
+  int32 channel_tag = 5;
+
+  // Length of audio processed so far in seconds
+  float audio_processed = 6;
+
+  // Message for pipeline states
+  optional PipelineStates pipeline_states = 7;
+}

--- a/src/riva-proto/riva/proto/riva_audio.proto
+++ b/src/riva-proto/riva/proto/riva_audio.proto
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+syntax = "proto3";
+
+package nvidia.riva;
+
+option cc_enable_arenas = true;
+option go_package = "nvidia.com/riva_speech";
+
+/*
+ * AudioEncoding specifies the encoding of the audio bytes in the encapsulating
+ * message.
+ */
+enum AudioEncoding {
+  // Not specified.
+  ENCODING_UNSPECIFIED = 0;
+
+  // Uncompressed 16-bit signed little-endian samples (Linear PCM).
+  LINEAR_PCM = 1;
+
+  // `FLAC` (Free Lossless Audio
+  // Codec) is the recommended encoding because it is
+  // lossless--therefore recognition is not compromised--and
+  // requires only about half the bandwidth of `LINEAR16`. `FLAC` stream
+  // encoding supports 16-bit and 24-bit samples, however, not all fields in
+  // `STREAMINFO` are supported.
+  FLAC = 2;
+
+  // 8-bit samples that compand 14-bit audio samples using G.711 PCMU/mu-law.
+  MULAW = 3;
+
+  OGGOPUS = 4;
+
+  // 8-bit samples that compand 13-bit audio samples using G.711 PCMU/a-law.
+  ALAW = 20;
+}

--- a/src/riva-proto/riva/proto/riva_common.proto
+++ b/src/riva-proto/riva/proto/riva_common.proto
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+syntax = "proto3";
+
+package nvidia.riva;
+
+option cc_enable_arenas = true;
+option go_package = "nvidia.com/riva_speech";
+
+/*
+ * Specifies the request ID of the request.
+ */
+message RequestId {
+  string value = 1;
+}

--- a/src/riva-whisper.js
+++ b/src/riva-whisper.js
@@ -1,0 +1,65 @@
+// NVIDIA NIM speech transcription (Riva ASR gRPC) using the hosted whisper-large-v3 model.
+// Runs on NVIDIA's cloud GPUs instead of local CPU, avoiding local Whisper's
+// unusably slow large-v3 inference time on machines without a capable GPU.
+// Requires an NVCF function-id alongside the API key (from the model's "API"
+// tab on build.nvidia.com/openai/whisper-large-v3).
+const path = require('path');
+
+const RIVA_ENDPOINT = 'grpc.nvcf.nvidia.com:443';
+const RIVA_MODEL = 'whisper-large-v3-multi-asr-offline-asr-bls-ensemble';
+
+let cachedClient = null;
+
+function getClient() {
+  if (cachedClient) return cachedClient;
+  const grpc = require('@grpc/grpc-js');
+  const protoLoader = require('@grpc/proto-loader');
+  const protoDir = path.join(__dirname, 'riva-proto');
+  const packageDef = protoLoader.loadSync(path.join(protoDir, 'riva', 'proto', 'riva_asr.proto'), {
+    keepCase: true, longs: String, enums: String, defaults: true, oneofs: true,
+    includeDirs: [protoDir]
+  });
+  const proto = grpc.loadPackageDefinition(packageDef).nvidia.riva.asr;
+  cachedClient = { proto, grpc };
+  return cachedClient;
+}
+
+function transcribeNvidiaWhisper(apiKey, functionId, wav) {
+  const { proto, grpc } = getClient();
+  const pcm = wav.subarray(44); // strip the 44-byte WAV header written by pcmToWav; Riva wants raw LINEAR_PCM
+
+  const metaCallCreds = grpc.credentials.createFromMetadataGenerator((params, cb) => {
+    const md = new grpc.Metadata();
+    md.set('authorization', 'Bearer ' + apiKey);
+    md.set('function-id', functionId);
+    cb(null, md);
+  });
+  const channelCreds = grpc.credentials.combineChannelCredentials(
+    grpc.credentials.createSsl(),
+    metaCallCreds
+  );
+  const client = new proto.RivaSpeechRecognition(RIVA_ENDPOINT, channelCreds);
+
+  const deadline = new Date();
+  deadline.setSeconds(deadline.getSeconds() + 20);
+
+  return new Promise((resolve, reject) => {
+    client.Recognize({
+      config: {
+        encoding: 'LINEAR_PCM',
+        sample_rate_hertz: 16000,
+        language_code: 'en-US',
+        max_alternatives: 1,
+        model: RIVA_MODEL
+      },
+      audio: pcm
+    }, { deadline }, (err, resp) => {
+      client.close();
+      if (err) return reject(err);
+      const alt = resp.results && resp.results[0] && resp.results[0].alternatives && resp.results[0].alternatives[0];
+      resolve((alt && alt.transcript || '').trim());
+    });
+  });
+}
+
+module.exports = { transcribeNvidiaWhisper };

--- a/src/store.js
+++ b/src/store.js
@@ -14,7 +14,7 @@ const DEFAULTS = {
   provider: 'openai',
   sttProvider: 'auto',
   localWhisper: {
-    modelId: 'base.en',
+    modelId: 'large-v3',
     language: 'auto',
     threads: 0
   },
@@ -46,9 +46,9 @@ const DEFAULTS = {
     openai: { fast: 'gpt-4o-mini', smart: 'gpt-4o' },
     anthropic: { fast: 'claude-3-5-haiku-latest', smart: 'claude-3-5-sonnet-latest' },
     // Kept in sync with CURRENT_GEMINI_DEFAULT in src/llm.js — gemini-2.0-flash
-    // (the previous default here) was retired by Google on 2026-03-03 and 404s
-    // on every request. gemini-2.5-flash is current and free-tier available.
-    gemini: { fast: 'gemini-2.5-flash', smart: 'gemini-2.5-flash' },
+    // (the original default here) was retired by Google on 2026-03-03 and 404s
+    // on every request. gemma-4-31b-it is Google's current flagship Gemma model.
+    gemini: { fast: 'gemma-4-31b-it', smart: 'gemma-4-31b-it' },
     custom: { fast: '', smart: '' },
     ollama: { fast: 'llama3.2', smart: 'llama3.3' },
     groq: { fast: 'llama-3.1-8b-instant', smart: 'llama-3.3-70b-versatile' },

--- a/src/store.js
+++ b/src/store.js
@@ -14,15 +14,19 @@ const DEFAULTS = {
   provider: 'openai',
   sttProvider: 'auto',
   localWhisper: {
-    modelId: 'large-v3',
+    modelId: 'base.en',
     language: 'auto',
     threads: 0
   },
   smart: false,
   baseUrl: '',
   minimaxRegion: 'global_en',
-  apiKeys: { openai: '', anthropic: '', gemini: '', deepgram: '', custom: '', ollama: '', groq: '', minimax: '' , azure: '' },
+  apiKeys: { openai: '', anthropic: '', gemini: '', deepgram: '', custom: '', ollama: '', groq: '', minimax: '' , azure: '', nvidia: '' },
   azureEndpoint: '',
+  // NVCF function-id for the hosted whisper-large-v3 NIM (from the model's
+  // "API" tab on build.nvidia.com/openai/whisper-large-v3) — required
+  // alongside apiKeys.nvidia because Riva ASR calls are per-deployment.
+  nvidiaFunctionId: '',
   // Tab 2: Profile
   resumeText: '',
   jobDescription: '',

--- a/src/stt-streaming.js
+++ b/src/stt-streaming.js
@@ -6,7 +6,7 @@
 
 const { looksLikeHallucination } = require('./stt');
 const { pcmToWav } = require('./wav');
-const { CURRENT_GEMINI_DEFAULT } = require('./llm');
+const { CURRENT_GEMINI_AUDIO_MODEL } = require('./llm');
 
 // ============================================================================
 // OpenAI Realtime Transcription Session (WebSocket)
@@ -389,7 +389,7 @@ async function transcribeBatchGemini(apiKey, wav) {
   const { GoogleGenAI } = require('@google/genai');
   const ai = new GoogleGenAI({ apiKey });
   const res = await ai.models.generateContent({
-    model: CURRENT_GEMINI_DEFAULT,
+    model: CURRENT_GEMINI_AUDIO_MODEL,
     contents: [{ role: 'user', parts: [
       { text: 'Transcribe this audio verbatim. Return only the spoken words with no commentary. If there is no clear speech, return an empty response.' },
       { inlineData: { mimeType: 'audio/wav', data: wav.toString('base64') } }

--- a/src/stt-streaming.js
+++ b/src/stt-streaming.js
@@ -409,7 +409,7 @@ function createStreamingSTT(settings, channel, callbacks) {
   const selectedProvider = settings.sttProvider || 'auto';
   const { onTranscript, onInterim, onError, onStatusChange } = callbacks;
 
-  if (selectedProvider === 'local' || selectedProvider === 'gemini') {
+  if (selectedProvider === 'local' || selectedProvider === 'gemini' || selectedProvider === 'nvidia') {
     return { type: 'batch', provider: selectedProvider, instance: null };
   }
 
@@ -437,10 +437,11 @@ function createStreamingSTT(settings, channel, callbacks) {
     return { type: 'streaming', provider: 'openai-realtime', instance: stt };
   }
 
-  // Priority 3: Batch fallback (Gemini or Whisper via old system)
+  // Priority 3: Batch fallback (Gemini, NVIDIA, or Whisper via old system)
+  const autoFallback = keys.gemini ? 'gemini' : (keys.nvidia && settings.nvidiaFunctionId ? 'nvidia' : 'none');
   return {
     type: 'batch',
-    provider: selectedProvider === 'auto' && keys.gemini ? 'gemini' : 'none',
+    provider: selectedProvider === 'auto' ? autoFallback : 'none',
     instance: null
   };
 }

--- a/src/stt.js
+++ b/src/stt.js
@@ -2,7 +2,7 @@
 // no audio API — we transcribe with whatever audio-capable key is available, and
 // fall back across providers. Returns { text, provider } or { text:'', error }.
 const { pcmToWav } = require('./wav');
-const { formatProviderErrorMessage, isQuotaError, CURRENT_GEMINI_DEFAULT } = require('./llm');
+const { formatProviderErrorMessage, isQuotaError, CURRENT_GEMINI_AUDIO_MODEL } = require('./llm');
 
 const BASE_VOCAB = 'CI/CD, Docker, Kubernetes, Terraform, Jenkins, AWS, Azure, GCP, ' +
   'CodeCommit, CodePipeline, CodeBuild, CodeDeploy, DevOps, SRE, microservices, deployment, ' +
@@ -49,7 +49,7 @@ async function transcribeGemini(apiKey, wav) {
   const { GoogleGenAI } = require('@google/genai');
   const ai = new GoogleGenAI({ apiKey });
   const res = await ai.models.generateContent({
-    model: CURRENT_GEMINI_DEFAULT,
+    model: CURRENT_GEMINI_AUDIO_MODEL,
     contents: [{ role: 'user', parts: [
       { text: 'Transcribe this audio verbatim. Return only the spoken words with no commentary. If there is no clear speech, return an empty response.' },
       { inlineData: { mimeType: 'audio/wav', data: wav.toString('base64') } }

--- a/src/stt.js
+++ b/src/stt.js
@@ -3,6 +3,7 @@
 // fall back across providers. Returns { text, provider } or { text:'', error }.
 const { pcmToWav } = require('./wav');
 const { formatProviderErrorMessage, isQuotaError, CURRENT_GEMINI_AUDIO_MODEL } = require('./llm');
+const { transcribeNvidiaWhisper } = require('./riva-whisper');
 
 const BASE_VOCAB = 'CI/CD, Docker, Kubernetes, Terraform, Jenkins, AWS, Azure, GCP, ' +
   'CodeCommit, CodePipeline, CodeBuild, CodeDeploy, DevOps, SRE, microservices, deployment, ' +
@@ -71,6 +72,9 @@ function createSTT(settings) {
   }
   if ((selectedProvider === 'auto' || selectedProvider === 'gemini') && keys.gemini) {
     chain.push({ p: 'gemini', fn: (wav) => transcribeGemini(keys.gemini, wav) });
+  }
+  if ((selectedProvider === 'auto' || selectedProvider === 'nvidia') && keys.nvidia && settings.nvidiaFunctionId) {
+    chain.push({ p: 'nvidia', fn: (wav) => transcribeNvidiaWhisper(keys.nvidia, settings.nvidiaFunctionId, wav) });
   }
   if (keys.openai && chain.length > 1) chain.unshift(chain.splice(chain.findIndex((c) => c.p === 'openai'), 1)[0]);
 

--- a/test/llm.test.js
+++ b/test/llm.test.js
@@ -255,7 +255,7 @@ test('createLLM: falls back to CURRENT_GEMINI_DEFAULT when no model is configure
 
 test('createLLM: a fresh install (store.js DEFAULTS shape) resolves to the current default', () => {
   const llm = createLLM(geminiSettings({
-    models: { gemini: { fast: 'gemini-2.5-flash', smart: 'gemini-2.5-flash' } }
+    models: { gemini: { fast: 'gemma-4-31b-it', smart: 'gemma-4-31b-it' } }
   }));
   assert.equal(llm.model, CURRENT_GEMINI_DEFAULT);
 });

--- a/test/stt-provider-selection.test.js
+++ b/test/stt-provider-selection.test.js
@@ -35,3 +35,27 @@ test('explicit cloud selection does not cross-fallback to another provider', () 
   assert.deepEqual(openai.providers, ['openai']);
   assert.deepEqual(gemini.providers, ['gemini']);
 });
+
+test('nvidia STT requires both an API key and a function-id', () => {
+  const missingFunctionId = createSTT({
+    sttProvider: 'nvidia',
+    apiKeys: { nvidia: 'nvidia-key' }
+  });
+  assert.equal(missingFunctionId.available, false);
+
+  const configured = createSTT({
+    sttProvider: 'nvidia',
+    apiKeys: { nvidia: 'nvidia-key' },
+    nvidiaFunctionId: 'test-function-id'
+  });
+  assert.deepEqual(configured.providers, ['nvidia']);
+});
+
+test('explicit nvidia selection does not cross-fallback to another provider', () => {
+  const nvidia = createSTT({
+    sttProvider: 'nvidia',
+    apiKeys: { openai: 'openai-key', gemini: 'gemini-key', nvidia: 'nvidia-key' },
+    nvidiaFunctionId: 'test-function-id'
+  });
+  assert.deepEqual(nvidia.providers, ['nvidia']);
+});


### PR DESCRIPTION
CURRENT_GEMINI_DEFAULT now points at Google's current flagship Gemma model instead of gemini-2.5-flash. Since gemma-4-31b-it doesn't accept audio input, transcription call sites in stt.js/stt-streaming.js are split onto a new CURRENT_GEMINI_AUDIO_MODEL constant so Gemini-based STT keeps working. Local Whisper's default model moves from base.en to large-v3 for better transcription accuracy out of the box.