### PR TITLE
fix(stt): transcribe with the configured Gemini model, not a hardcoded one

### DIFF
--- a/src/llm.js
+++ b/src/llm.js
@@ -5,11 +5,13 @@ const { createCompatibleClientOptions } = require('./openai-compatible');
 
 const CUSTOM_PROVIDER = 'custom';
 // gemini-2.0-flash was Google's default here until it was deprecated (Feb 2026)
-// and fully retired (Mar 3 2026) — every request against it now 404s with a
-// generic "exception parsing response" body. gemini-2.5-flash is the model
-// Google's own SDK examples standardize on and is documented as free-tier
-// available, so it is the single default used everywhere in this file.
-const CURRENT_GEMINI_DEFAULT = 'gemini-2.5-flash';
+// and fully retired (Mar 3 2026). Its replacement, gemini-2.5-flash, has since
+// been closed to new API keys — Google answers those requests with
+// "This model models/gemini-2.5-flash is no longer available to new users",
+// a 404 that reads as a dead model to anyone who signed up recently. Google
+// names gemini-3.6-flash as 2.5-flash's successor, so that is the single
+// default used everywhere in this file.
+const CURRENT_GEMINI_DEFAULT = 'gemini-3.6-flash';
 const DEFAULT_MODELS = {
   openai: 'gpt-4o-mini',
   anthropic: 'claude-3-5-haiku-latest',
@@ -20,11 +22,26 @@ const DEFAULT_MODELS = {
   azure: 'gpt-4o-mini'
 };
 
-// Gemini model ids that Google has since deprecated/retired. A settings file
-// saved before this fix can still have one of these persisted on disk, so
-// createLLM migrates them at read time rather than only fixing the default —
-// otherwise an existing user would keep re-hitting the same 404 forever.
-const DEAD_GEMINI_MODEL_RE = /^gemini-(1\.0|1\.5|2\.0)(?:-|$)/i;
+// Gemini model ids that Google has since deprecated/retired/closed to new keys.
+// A settings file saved before this fix can still have one of these persisted
+// on disk, so resolveGeminiModel migrates them at read time rather than only
+// fixing the default — otherwise an existing user would keep re-hitting the
+// same 404 forever.
+const DEAD_GEMINI_MODEL_RE = /^gemini-(1\.0|1\.5|2\.0|2\.5)(?:-|$)/i;
+
+// Single place that answers "which Gemini model should this request use?".
+// Both the chat path (createLLM) and the transcription paths (src/stt.js,
+// src/stt-streaming.js) go through here. STT used to skip this and hardcode
+// the default instead, so a user who picked a working model in Settings still
+// got 404s from a model they had never selected — the app reported a failure
+// against a model id that appeared nowhere in their config.
+function resolveGeminiModel(settings) {
+  const s = settings || {};
+  const tier = s.smart ? 'smart' : 'fast';
+  const configured = ((s.models || {}).gemini || {})[tier];
+  if (!configured || DEAD_GEMINI_MODEL_RE.test(configured)) return CURRENT_GEMINI_DEFAULT;
+  return configured;
+}
 
 const PROVIDER_LABELS = { azure: 'Azure AI Foundry', openai: 'OpenAI', minimax: 'MiniMax' };
 
@@ -301,8 +318,8 @@ function createLLM(settings) {
   const tier = settings.smart ? 'smart' : 'fast';
   const models = settings.models || {};
   let model = (models[provider] || {})[tier];
-  if (provider === 'gemini' && DEAD_GEMINI_MODEL_RE.test(model || '')) {
-    model = CURRENT_GEMINI_DEFAULT;
+  if (provider === 'gemini') {
+    model = resolveGeminiModel(settings);
   }
   if (!model) model = DEFAULT_MODELS[provider] || '';
   const minimaxRegion = settings.minimaxRegion || 'global_en';
@@ -356,4 +373,4 @@ function createLLM(settings) {
   };
 }
 
-module.exports = { createLLM, formatProviderErrorMessage, isQuotaError, CURRENT_GEMINI_DEFAULT };
+module.exports = { createLLM, formatProviderErrorMessage, isQuotaError, resolveGeminiModel, CURRENT_GEMINI_DEFAULT };

--- a/src/store.js
+++ b/src/store.js
@@ -45,10 +45,10 @@ const DEFAULTS = {
   models: {
     openai: { fast: 'gpt-4o-mini', smart: 'gpt-4o' },
     anthropic: { fast: 'claude-3-5-haiku-latest', smart: 'claude-3-5-sonnet-latest' },
-    // Kept in sync with CURRENT_GEMINI_DEFAULT in src/llm.js — gemini-2.0-flash
-    // (the previous default here) was retired by Google on 2026-03-03 and 404s
-    // on every request. gemini-2.5-flash is current and free-tier available.
-    gemini: { fast: 'gemini-2.5-flash', smart: 'gemini-2.5-flash' },
+    // Kept in sync with CURRENT_GEMINI_DEFAULT in src/llm.js. gemini-2.0-flash
+    // was retired 2026-03-03 and gemini-2.5-flash is closed to new API keys, so
+    // both 404. gemini-3.6-flash is Google's named successor to 2.5-flash.
+    gemini: { fast: 'gemini-3.6-flash', smart: 'gemini-3.6-flash' },
     custom: { fast: '', smart: '' },
     ollama: { fast: 'llama3.2', smart: 'llama3.3' },
     groq: { fast: 'llama-3.1-8b-instant', smart: 'llama-3.3-70b-versatile' },

--- a/src/stt-streaming.js
+++ b/src/stt-streaming.js
@@ -6,7 +6,7 @@
 
 const { looksLikeHallucination } = require('./stt');
 const { pcmToWav } = require('./wav');
-const { CURRENT_GEMINI_DEFAULT } = require('./llm');
+const { resolveGeminiModel } = require('./llm');
 
 // ============================================================================
 // OpenAI Realtime Transcription Session (WebSocket)
@@ -385,11 +385,11 @@ async function transcribeBatchOpenAI(apiKey, wav, model) {
   return (typeof res === 'string' ? res : res.text || '').trim();
 }
 
-async function transcribeBatchGemini(apiKey, wav) {
+async function transcribeBatchGemini(apiKey, wav, model) {
   const { GoogleGenAI } = require('@google/genai');
   const ai = new GoogleGenAI({ apiKey });
   const res = await ai.models.generateContent({
-    model: CURRENT_GEMINI_DEFAULT,
+    model: model || resolveGeminiModel(),
     contents: [{ role: 'user', parts: [
       { text: 'Transcribe this audio verbatim. Return only the spoken words with no commentary. If there is no clear speech, return an empty response.' },
       { inlineData: { mimeType: 'audio/wav', data: wav.toString('base64') } }

--- a/src/stt.js
+++ b/src/stt.js
@@ -2,7 +2,7 @@
 // no audio API — we transcribe with whatever audio-capable key is available, and
 // fall back across providers. Returns { text, provider } or { text:'', error }.
 const { pcmToWav } = require('./wav');
-const { formatProviderErrorMessage, isQuotaError, CURRENT_GEMINI_DEFAULT } = require('./llm');
+const { formatProviderErrorMessage, isQuotaError, resolveGeminiModel } = require('./llm');
 
 const BASE_VOCAB = 'CI/CD, Docker, Kubernetes, Terraform, Jenkins, AWS, Azure, GCP, ' +
   'CodeCommit, CodePipeline, CodeBuild, CodeDeploy, DevOps, SRE, microservices, deployment, ' +
@@ -45,11 +45,11 @@ async function transcribeOpenAI(apiKey, wav, model, baseURL, prompt) {
   return (res.text || '').trim();
 }
 
-async function transcribeGemini(apiKey, wav) {
+async function transcribeGemini(apiKey, wav, model) {
   const { GoogleGenAI } = require('@google/genai');
   const ai = new GoogleGenAI({ apiKey });
   const res = await ai.models.generateContent({
-    model: CURRENT_GEMINI_DEFAULT,
+    model,
     contents: [{ role: 'user', parts: [
       { text: 'Transcribe this audio verbatim. Return only the spoken words with no commentary. If there is no clear speech, return an empty response.' },
       { inlineData: { mimeType: 'audio/wav', data: wav.toString('base64') } }
@@ -63,14 +63,19 @@ function createSTT(settings) {
   const selectedProvider = settings.sttProvider || 'auto';
   const vocabPrompt = buildVocabPrompt(settings);
   const chain = [];
+  // Each entry carries the model id it actually sends, so a failure can name
+  // that id back to the user instead of a hardcoded one they never picked.
   if ((selectedProvider === 'auto' || selectedProvider === 'openai') && keys.openai) {
-    chain.push({ p: 'openai', fn: (wav) => transcribeOpenAI(keys.openai, wav, settings.sttModel, undefined, vocabPrompt) });
+    const model = settings.sttModel || 'whisper-1';
+    chain.push({ p: 'openai', m: model, fn: (wav) => transcribeOpenAI(keys.openai, wav, model, undefined, vocabPrompt) });
   }
   if ((selectedProvider === 'auto' || selectedProvider === 'groq') && keys.groq) {
-    chain.push({ p: 'groq', fn: (wav) => transcribeOpenAI(keys.groq, wav, 'whisper-large-v3-turbo', 'https://api.groq.com/openai/v1', vocabPrompt) });
+    const model = 'whisper-large-v3-turbo';
+    chain.push({ p: 'groq', m: model, fn: (wav) => transcribeOpenAI(keys.groq, wav, model, 'https://api.groq.com/openai/v1', vocabPrompt) });
   }
   if ((selectedProvider === 'auto' || selectedProvider === 'gemini') && keys.gemini) {
-    chain.push({ p: 'gemini', fn: (wav) => transcribeGemini(keys.gemini, wav) });
+    const model = resolveGeminiModel(settings);
+    chain.push({ p: 'gemini', m: model, fn: (wav) => transcribeGemini(keys.gemini, wav, model) });
   }
   if (keys.openai && chain.length > 1) chain.unshift(chain.splice(chain.findIndex((c) => c.p === 'openai'), 1)[0]);
 
@@ -80,6 +85,7 @@ function createSTT(settings) {
   return {
     available: chain.length > 0,
     providers: chain.map((c) => c.p),
+    models: chain.map((c) => c.m),
     async transcribe(pcm) {
       if (!chain.length || !pcm || pcm.length < 3200) return { text: '' };
       const now = Date.now();
@@ -98,8 +104,8 @@ function createSTT(settings) {
           // 404 (dead/misspelled model) or 429 (quota) reads the same whether it
           // came from a chat request or a transcription request.
           const quota = isQuotaError(e);
-          const message = formatProviderErrorMessage(e, c.p);
-          lastErr = { status: e && e.status, code: e && e.code, message, provider: c.p };
+          const message = formatProviderErrorMessage(e, c.p, c.m);
+          lastErr = { status: e && e.status, code: e && e.code, message, provider: c.p, model: c.m };
           if (quota) {
             lastProvider = c.p;
             disabledUntil = now + 30000;

--- a/test/gemini-model-config.test.js
+++ b/test/gemini-model-config.test.js
@@ -12,7 +12,7 @@ const { CURRENT_GEMINI_DEFAULT } = require('../src/llm');
 // Gemini model id (two still pointing at the dead one), so this scans every
 // source file that talks to the Gemini API and fails if a known-retired id
 // or a hardcoded id that has drifted from the shared default sneaks back in.
-const DEAD_MODEL_IDS = ['gemini-2.0-flash', 'gemini-1.5-flash', 'gemini-1.5-pro', 'gemini-1.0-pro'];
+const DEAD_MODEL_IDS = ['gemini-2.0-flash', 'gemini-2.5-flash', 'gemini-1.5-flash', 'gemini-1.5-pro', 'gemini-1.0-pro'];
 
 const FILES_THAT_CALL_GEMINI = [
   'src/llm.js',

--- a/test/llm.test.js
+++ b/test/llm.test.js
@@ -190,7 +190,7 @@ test('formatProviderErrorMessage: maps a Gemini 429 to a free-tier quota message
     status: 429,
     body: { error: { message: 'You exceeded your current quota', code: 429, status: 'RESOURCE_EXHAUSTED' } }
   });
-  const message = formatProviderErrorMessage(error, 'gemini', 'gemini-2.5-flash');
+  const message = formatProviderErrorMessage(error, 'gemini', 'gemini-3.6-flash');
   assert.match(message, /Gemini free-tier quota exhausted \(429/);
   assert.match(message, /billing/);
   assert.doesNotMatch(message, /RESOURCE_EXHAUSTED/);
@@ -255,7 +255,7 @@ test('createLLM: falls back to CURRENT_GEMINI_DEFAULT when no model is configure
 
 test('createLLM: a fresh install (store.js DEFAULTS shape) resolves to the current default', () => {
   const llm = createLLM(geminiSettings({
-    models: { gemini: { fast: 'gemini-2.5-flash', smart: 'gemini-2.5-flash' } }
+    models: { gemini: { fast: 'gemini-3.6-flash', smart: 'gemini-3.6-flash' } }
   }));
   assert.equal(llm.model, CURRENT_GEMINI_DEFAULT);
 });
@@ -280,4 +280,11 @@ test('createLLM: leaves a user-chosen current Gemini model alone', () => {
     models: { gemini: { fast: 'gemini-3.5-flash', smart: 'gemini-3.5-flash' } }
   }));
   assert.equal(llm.model, 'gemini-3.5-flash');
+});
+
+test('createLLM: self-heals gemini-2.5-* , which Google closed to new API keys', () => {
+  const llm = createLLM(geminiSettings({
+    models: { gemini: { fast: 'gemini-2.5-flash', smart: 'gemini-2.5-flash-lite' } }
+  }));
+  assert.equal(llm.model, CURRENT_GEMINI_DEFAULT);
 });

--- a/test/stt-provider-selection.test.js
+++ b/test/stt-provider-selection.test.js
@@ -2,6 +2,7 @@ const assert = require('node:assert/strict');
 const test = require('node:test');
 const { createSTT } = require('../src/stt');
 const { createStreamingSTT } = require('../src/stt-streaming');
+const { CURRENT_GEMINI_DEFAULT } = require('../src/llm');
 
 const callbacks = {
   onTranscript() {},
@@ -34,4 +35,36 @@ test('explicit cloud selection does not cross-fallback to another provider', () 
   });
   assert.deepEqual(openai.providers, ['openai']);
   assert.deepEqual(gemini.providers, ['gemini']);
+});
+
+// Regression for issue #25: Settings held a working Gemini model, but the STT
+// path ignored settings.models entirely and hardcoded its own id — so
+// transcription 404'd against a model the user had never selected, and the
+// error text named that unfamiliar id back at them.
+test('Gemini STT transcribes with the model configured in Settings', () => {
+  const stt = createSTT({
+    sttProvider: 'gemini',
+    apiKeys: { gemini: 'gemini-key' },
+    models: { gemini: { fast: 'gemini-3.5-flash-lite', smart: 'gemini-3.6-flash' } }
+  });
+  assert.deepEqual(stt.models, ['gemini-3.5-flash-lite']);
+});
+
+test('Gemini STT honours the smart tier the same way the chat path does', () => {
+  const stt = createSTT({
+    sttProvider: 'gemini',
+    smart: true,
+    apiKeys: { gemini: 'gemini-key' },
+    models: { gemini: { fast: 'gemini-3.5-flash-lite', smart: 'gemini-3.6-flash' } }
+  });
+  assert.deepEqual(stt.models, ['gemini-3.6-flash']);
+});
+
+test('Gemini STT migrates a retired model saved on disk instead of 404ing forever', () => {
+  const stt = createSTT({
+    sttProvider: 'gemini',
+    apiKeys: { gemini: 'gemini-key' },
+    models: { gemini: { fast: 'gemini-2.5-flash', smart: 'gemini-2.5-flash' } }
+  });
+  assert.deepEqual(stt.models, [CURRENT_GEMINI_DEFAULT]);
 });


### PR DESCRIPTION
Fixes #25.

## The bug

Transcription fails with a 404 naming a model the user never selected:

```
Transcription error (gemini): got status: 404 Not Found.
"This model models/gemini-2.5-flash is no longer available to new users."
```

…while Settings holds something entirely different (`gemini-3.5-flash` in #25). As @vamsivishwanadh put it on that issue: *"Don't understand why it is defaulting to gemini-2.5-flash even after selecting any other model."*

## Cause

Two independent problems that combine into a confusing error.

**1. STT never read the user's model setting.** `createLLM` resolves `settings.models.gemini[tier]`, but `src/stt.js` and `src/stt-streaming.js` passed `CURRENT_GEMINI_DEFAULT` straight to `generateContent`. Chat honoured Settings; transcription silently ignored it. That is why the error names an id that appears nowhere in the user's config — and why "change the model in Settings" doesn't fix it.

**2. `gemini-2.5-flash` is no longer a safe default.** It isn't retired — shutdown is Oct 16 2026 — but Google has **closed it to new API keys**. Keys issued recently get `no longer available to new users`, a 404 that behaves exactly like the retired `gemini-2.0-flash` did. This is independent of billing tier; #25 reports it on paid tiers too.

## Fix

- New `resolveGeminiModel(settings)` in `src/llm.js` — one place that answers "which Gemini model?", now shared by `createLLM` and both transcription paths.
- `gemini-2.5-*` joins `DEAD_GEMINI_MODEL_RE`, so a settings file already holding it is migrated on read rather than 404ing forever.
- Shared default moves to `gemini-3.6-flash`: Google names it as 2.5-flash's successor, and it is the model used throughout [Google's own audio-understanding docs](https://ai.google.dev/gemini-api/docs/audio), so it is a documented fit for the `inlineData` audio calls these paths make.
- STT errors now report the model actually sent, so the next report of this class is self-diagnosing.

## Tests

`npm test` → 134 passing. Four new cases: Gemini STT uses the configured model, honours the smart/fast tier, migrates a retired id, and `createLLM` self-heals `gemini-2.5-*`. The existing `gemini-model-config.test.js` guard — which scans every Gemini-calling file for hardcoded dead ids — now covers `2.5` as well.

## Note on scope

This does not touch `@google/genai`. #33 (new `AQ.` key format vs the pinned `0.3.x` SDK) is already fixed on `main` via `^2.12.0`; it just hasn't shipped in a release, so anyone on the 0.2.2 build still hits it.
