### PR TITLE
fix(ui): stop a listening session from stranding the toolbar off-screen

### DIFF
--- a/main.js
+++ b/main.js
@@ -190,7 +190,10 @@ function createWindow() {
 
   if (savedSettings.windowX !== null && savedSettings.windowY !== null) {
     const clampedX = Math.max(workArea.x - W + 100, Math.min(savedSettings.windowX, workArea.x + workArea.width - 100));
-    const clampedY = Math.max(workArea.y, Math.min(savedSettings.windowY, workArea.y + workArea.height - 40));
+    // Keep the whole window on screen, not just a 40px sliver of it. The old
+    // `- 40` let a 600px-tall window sit at y=607 on a 960px display, pushing
+    // the composer and action row off the bottom edge with no way to reach them.
+    const clampedY = Math.max(workArea.y, Math.min(savedSettings.windowY, workArea.y + workArea.height - H));
     startX = clampedX;
     startY = clampedY;
   }

--- a/renderer/renderer.js
+++ b/renderer/renderer.js
@@ -1089,9 +1089,17 @@
     aiEl.appendChild(caretEl);
     group.appendChild(aiEl);
     messages.appendChild(group);
-    // Use requestAnimationFrame so the DOM is fully updated before scrolling
+    // Use requestAnimationFrame so the DOM is fully updated before scrolling.
+    // Scroll #messages directly rather than calling sep.scrollIntoView(): that
+    // scrolls *every* scrollable ancestor, and once the panel is tall enough it
+    // scrolls the document too, aligning the separator to the top of the window
+    // and pushing #toolbar out of view. html/body are overflow:hidden, so there
+    // is no scrollbar or wheel gesture to undo it — the Stop/Hide/Quit controls
+    // just never come back.
     requestAnimationFrame(() => {
-      if (sep && sep.isConnected) sep.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      if (sep && sep.isConnected) {
+        messages.scrollTo({ top: sep.offsetTop - messages.offsetTop, behavior: 'smooth' });
+      }
     });
     setBusy(true);
   });
@@ -1592,6 +1600,13 @@
     if (e.key === 'Escape' && !scrim.classList.contains('hidden')) closeSettings();
     if ((e.metaKey || e.ctrlKey) && e.key === ',') { e.preventDefault(); openSettings(); }
   });
+
+  // Safety net for the same class of bug: html/body are overflow:hidden, so any
+  // stray programmatic scroll of the document is invisible to the user and
+  // unrecoverable by mouse. Snap it back so the toolbar cannot be stranded.
+  window.addEventListener('scroll', () => {
+    if (window.scrollY || window.scrollX) window.scrollTo(0, 0);
+  }, { passive: true });
 
   // ---- click-through: only the UI blocks the mouse; empty gaps pass to your screen ----
   let ignoring = null;

--- a/renderer/styles.css
+++ b/renderer/styles.css
@@ -53,6 +53,10 @@ html, body {
   pointer-events: none;                  /* only the actual UI blocks; gaps pass through */
 }
 #toolbar, #panel-wrap, #settings-scrim, #onboard-scrim, #consent-scrim { pointer-events: auto; }
+/* #app is a flex column: without this the toolbar is a shrinkable flex item, so
+   a tall panel (long transcript, long response) squeezes the Stop/Hide/Quit
+   controls down to nothing and leaves no way to stop listening. */
+#toolbar { flex-shrink: 0; }
 #toolbar { -webkit-app-region: drag; }   /* drag the top pill to move the window */
 #panel-wrap, #panel, #messages, #action-row, #composer, #input, textarea, button, .act, .smart-pill, .more-btn, #send-btn, .s-close, .s-seg button, .ob-buttons button, .ob-ghost, .ob-primary { -webkit-app-region: no-drag; }
 


### PR DESCRIPTION
## The bug

Mid-listening-session, the toolbar (Stop / Hide / Quit) can vanish while the panel below it stays visible — leaving no way to stop transcription short of force-quitting the app. Reproduced by starting a session and letting a few responses accumulate; it can also strand the toolbar right after the user has already stopped listening.

## Root cause

`renderer.js`'s response handler calls, on every new AI response group:

```js
sep.scrollIntoView({ behavior: 'smooth', block: 'start' });
```

`scrollIntoView` scrolls **every** scrollable ancestor, not just `#messages`. Once the panel grows tall enough for the document to overflow the fixed 600px window, it scrolls the *document* too — pinning the separator to the top of the viewport, which pushes `#toolbar` above the visible area.

`html, body` are `overflow: hidden` (by design, for the frameless overlay), so this isn't recoverable with a scrollbar or wheel gesture. The toolbar is gone for the rest of the session, mic still live.

This only fires on a new AI response, not on transcription itself — which is why it can strand the bar even after the user has already pressed Stop.

## Two more overflow paths, found while chasing this

Not the primary cause (the panel stays visible when the bug hits, and both of these move things by only tens of pixels), but both are real and worth closing while touching this area:

- `main.js` clamped a restored window position to `workArea.y + workArea.height - 40` — only 40px of the window is guaranteed on-screen. A 700x600 window restored near the bottom of a shorter display can lose real UI off the bottom edge. Clamped against the window height instead.
- `#toolbar` is a flex item of the `#app` column with default `flex-shrink`, so a sufficiently tall panel can squeeze it. Pinned with `flex-shrink: 0`.

## Fix

- Scroll `#messages` directly instead of calling `scrollIntoView` on a descendant.
- Added a `window.addEventListener('scroll', …)` safety net that snaps any stray document scroll back to `(0,0)`, so the same class of bug can't strand the toolbar again even if something else triggers a document-level scroll later.

## Testing

`npm test` → 130 passing (this branch doesn't include the unrelated Gemini-model fix in #51, so the count differs from that PR).

Separated from #51 — no overlap, different files, easier to review independently.
