### PR TITLE
fix(audio): pass 'loopback' string in setDisplayMediaRequestHandler f…

### DIFF
--- a/main.js
+++ b/main.js
@@ -776,10 +776,7 @@ function launchApp() {
   session.defaultSession.setDisplayMediaRequestHandler((_request, callback) => {
     desktopCapturer.getSources({ types: ['screen'] }).then((sources) => {
       if (!sources.length) return callback();
-      const request = { video: sources[0] };
-      if (isWindows) request.audio = true;
-      else request.audio = 'loopback';
-      callback(request);
+      callback({ video: sources[0], audio: 'loopback' });
     }).catch(() => callback());
   }, { useSystemPicker: false });
 


### PR DESCRIPTION
When starting meeting audio capture on Windows, `setDisplayMediaRequestHandler` was passing `request.audio = true`. Electron expects `request.audio = 'loopback'`, which caused parameter errors and triggered the UI message: *"Meeting audio could not be started."*

Updated `setDisplayMediaRequestHandler` in `main.js` to explicitly pass `request.audio = 'loopback'` for system audio loopback capture.

Tested and verified on Windows: Successfully acquired system loopback track without permissions or type errors.