### PR TITLE
fix(store): atomic settings writes with backup recovery

### DIFF
--- a/src/settings-store-core.js
+++ b/src/settings-store-core.js
@@ -1,0 +1,203 @@
+// Durable JSON settings persistence for cue-data.json.
+//
+// Why this exists as its own module: the previous store wrote the settings
+// file with a bare fs.writeFileSync (which truncates the destination before
+// writing) and swallowed every error. A crash or power loss mid-write left
+// corrupt JSON, and load() then silently reset EVERY saved API key and
+// interview-prep field to blank on the next launch — unrecoverable, because
+// the next save overwrote whatever remained. It also could not be unit
+// tested at all, because it called app.getPath('userData') at require time,
+// which throws outside Electron.
+//
+// The store therefore takes the userData directory lazily (factory pattern,
+// like WhisperModelManager's injected userDataPath) and writes atomically:
+//   1. serialize to FILE.tmp          (a crash here leaves the real file intact)
+//   2. copy the previous FILE to FILE.bak   (best-effort, one generation)
+//   3. rename TMP over FILE           (atomic replace, Windows-safe in Node;
+//                                      falls back to an in-place write when
+//                                      another process briefly holds FILE —
+//                                      e.g. antivirus on Windows)
+// On load, a corrupt or truncated FILE is recovered from FILE.bak before
+// falling back to defaults, and every failure is logged instead of ignored.
+const fs = require('fs');
+const path = require('path');
+
+const MAX_AI_RULES_CHARS = 2000;
+
+function createSettingsStore(resolveUserDataDir, {
+  label = 'cue-data.json',
+  afterMerge,
+} = {}) {
+  let filePath = null;
+
+  // Paths are resolved on first use rather than at creation so that merely
+  // requiring this module never needs Electron (tests run on plain Node).
+  function p(file) {
+    if (!filePath) filePath = path.join(resolveUserDataDir(), file);
+    return filePath;
+  }
+  const mainPath = () => p(label);
+  const tmpPath = () => mainPath() + '.tmp';
+  const bakPath = () => mainPath() + '.bak';
+
+  let data = null;
+  let lastError = null;
+
+  function deepMerge(base, over) {
+    const out = Array.isArray(base) ? base.slice() : { ...base };
+    for (const k of Object.keys(over || {})) {
+      if (over[k] && typeof over[k] === 'object' && !Array.isArray(over[k]) && typeof base[k] === 'object') {
+        out[k] = deepMerge(base[k], over[k]);
+      } else {
+        if (k === 'aiRules' && typeof over[k] === 'string') {
+          out[k] = over[k].slice(0, MAX_AI_RULES_CHARS);
+        } else {
+          out[k] = over[k];
+        }
+      }
+    }
+    return out;
+  }
+
+  function parseJson(candidate) {
+    return JSON.parse(fs.readFileSync(candidate, 'utf8'));
+  }
+
+  function load() {
+    if (data) return data;
+
+    let parsed = null;
+    let mainMissing = false;
+    try {
+      parsed = parseJson(mainPath());
+    } catch (e) {
+      mainMissing = e && e.code === 'ENOENT';
+      if (!mainMissing) {
+        // Corrupt/truncated/unreadable is worth saying out loud; a missing
+        // file on first run is normal and stays quiet.
+        console.error('[cue] cannot read ' + mainPath() + ':', e && e.message);
+      }
+    }
+    if (parsed !== null) {
+      data = deepMerge(DEFAULTS, parsed);
+      return data;
+    }
+
+    // The main file is gone or unusable. A stale .bak from the previous good
+    // save is strictly better than blanking every key the user has stored.
+    try {
+      parsed = parseJson(bakPath());
+      console.error('[cue] ' + label + ' was lost or corrupt — recovered settings from backup');
+      data = deepMerge(DEFAULTS, parsed);
+      persist(); // best-effort heal so the corruption doesn't linger
+      return data;
+    } catch (bakErr) {
+      if (!(bakErr && bakErr.code === 'ENOENT')) {
+        console.error('[cue] cannot read backup ' + bakPath() + ':', bakErr && bakErr.message);
+      }
+    }
+
+    if (!mainMissing) {
+      console.error('[cue] no usable backup for ' + label + '; starting from defaults');
+    }
+    data = deepMerge(DEFAULTS, {});
+    return data;
+  }
+
+  // Serialize → snapshot the previous good state → atomic replace. Never
+  // throws: callers rely on setSettings not rejecting (the IPC handler can
+  // surface failures separately via lastSaveError()).
+  function persist() {
+    const json = JSON.stringify(data, null, 2);
+    fs.writeFileSync(tmpPath(), json);
+    try {
+      if (fs.existsSync(mainPath())) fs.copyFileSync(mainPath(), bakPath());
+    } catch (_) { /* backup is best-effort; never block the save */ }
+    try {
+      fs.renameSync(tmpPath(), mainPath());
+    } catch (_) {
+      // Windows: antivirus/indexers can hold the target open for a moment,
+      // making rename fail with EPERM. An in-place write still beats losing
+      // the user's keys over a transient lock.
+      fs.writeFileSync(mainPath(), json);
+      try { fs.unlinkSync(tmpPath()); } catch (_) {}
+    }
+  }
+
+  function save() {
+    try {
+      persist();
+      lastError = null;
+      return true;
+    } catch (e) {
+      lastError = e;
+      console.error('[cue] failed to save ' + label + ':', e && e.message);
+      return false;
+    }
+  }
+
+  const DEFAULTS = {
+    provider: 'openai',
+    sttProvider: 'auto',
+    localWhisper: {
+      modelId: 'base.en',
+      language: 'auto',
+      threads: 0
+    },
+    smart: false,
+    baseUrl: '',
+    minimaxRegion: 'global_en',
+    apiKeys: { openai: '', anthropic: '', gemini: '', deepgram: '', custom: '', ollama: '', groq: '', minimax: '' , azure: '' },
+    azureEndpoint: '',
+    // Tab 2: Profile
+    resumeText: '',
+    jobDescription: '',
+    // Tab 3: Interview Prep
+    starStories: '',       // 3-5 behavioral STAR stories in plain English
+    whyCompany: '',        // Why do you want to work here?
+    whyLeaving: '',        // Why are you leaving your current job?
+    workStyle: '',         // How you work, decision-making style, values
+    // Tab 4: Q&A
+    salaryTarget: '',      // e.g. "$150k-$180k base + equity"
+    questionsToAsk: '',    // Questions to ask the interviewer
+    // Tab 5: Style — custom response rules
+    // The user writes how the AI should write: e.g. "no em-dashes", "use bullet
+    // points", "casual tone". Applied to every LLM mode EXCEPT LeetCode (kept
+    // strict for coding problems).
+    aiRules: '',
+    // Window position
+    windowX: null,
+    windowY: null,
+    models: {
+      openai: { fast: 'gpt-4o-mini', smart: 'gpt-4o' },
+      anthropic: { fast: 'claude-3-5-haiku-latest', smart: 'claude-3-5-sonnet-latest' },
+      // Kept in sync with CURRENT_GEMINI_DEFAULT in src/llm.js — gemini-2.0-flash
+      // (the previous default here) was retired by Google on 2026-03-03 and 404s
+      // on every request. gemini-2.5-flash is current and free-tier available.
+      gemini: { fast: 'gemini-2.5-flash', smart: 'gemini-2.5-flash' },
+      custom: { fast: '', smart: '' },
+      ollama: { fast: 'llama3.2', smart: 'llama3.3' },
+      groq: { fast: 'llama-3.1-8b-instant', smart: 'llama-3.3-70b-versatile' },
+      minimax: { fast: 'MiniMax-M2.7', smart: 'MiniMax-M3' },
+      azure: { fast: 'gpt-4o-mini', smart: 'gpt-4o' }
+    }
+  };
+
+  return {
+    MAX_AI_RULES_CHARS,
+    getSettings() { return load(); },
+    setSettings(patch) {
+      load();
+      data = deepMerge(data, patch || {});
+      // Applied on writes only — matches the original store's behavior, where
+      // values loaded from disk were never re-normalized.
+      if (afterMerge) data = afterMerge(data);
+      save();
+      return data;
+    },
+    /** Null when the last save succeeded; the error otherwise. */
+    lastSaveError() { return lastError; },
+  };
+}
+
+module.exports = { createSettingsStore, MAX_AI_RULES_CHARS };

--- a/src/store.js
+++ b/src/store.js
@@ -1,99 +1,29 @@
 // Simple JSON-file settings store (avoids native modules so `npm install` stays clean).
-const fs = require('fs');
+//
+// The durability mechanics live in ./settings-store-core so they can be unit
+// tested without Electron; this file only wires it to cue's userData path and
+// keeps the public surface (getSettings/setSettings/MAX_AI_RULES_CHARS).
 const path = require('path');
 const { app } = require('electron');
+const { createSettingsStore, MAX_AI_RULES_CHARS } = require('./settings-store-core');
 const { normalizeBaseUrl } = require('./openai-compatible');
 
-const FILE = path.join(app.getPath('userData'), 'cue-data.json');
-
-// Cap on the user's custom response rules. Generous but bounded: anything longer
-// should live in a real prompt file, not in a settings field.
-const MAX_AI_RULES_CHARS = 2000;
-
-const DEFAULTS = {
-  provider: 'openai',
-  sttProvider: 'auto',
-  localWhisper: {
-    modelId: 'base.en',
-    language: 'auto',
-    threads: 0
-  },
-  smart: false,
-  baseUrl: '',
-  minimaxRegion: 'global_en',
-  apiKeys: { openai: '', anthropic: '', gemini: '', deepgram: '', custom: '', ollama: '', groq: '', minimax: '' , azure: '' },
-  azureEndpoint: '',
-  // Tab 2: Profile
-  resumeText: '',
-  jobDescription: '',
-  // Tab 3: Interview Prep
-  starStories: '',       // 3-5 behavioral STAR stories in plain English
-  whyCompany: '',        // Why do you want to work here?
-  whyLeaving: '',        // Why are you leaving your current job?
-  workStyle: '',         // How you work, decision-making style, values
-  // Tab 4: Q&A
-  salaryTarget: '',      // e.g. "$150k-$180k base + equity"
-  questionsToAsk: '',    // Questions to ask the interviewer
-  // Tab 5: Style — custom response rules
-  // The user writes how the AI should write: e.g. "no em-dashes", "use bullet
-  // points", "casual tone". Applied to every LLM mode EXCEPT LeetCode (kept
-  // strict for coding problems).
-  aiRules: '',
-  // Window position
-  windowX: null,
-  windowY: null,
-  models: {
-    openai: { fast: 'gpt-4o-mini', smart: 'gpt-4o' },
-    anthropic: { fast: 'claude-3-5-haiku-latest', smart: 'claude-3-5-sonnet-latest' },
-    // Kept in sync with CURRENT_GEMINI_DEFAULT in src/llm.js — gemini-2.0-flash
-    // (the previous default here) was retired by Google on 2026-03-03 and 404s
-    // on every request. gemini-2.5-flash is current and free-tier available.
-    gemini: { fast: 'gemini-2.5-flash', smart: 'gemini-2.5-flash' },
-    custom: { fast: '', smart: '' },
-    ollama: { fast: 'llama3.2', smart: 'llama3.3' },
-    groq: { fast: 'llama-3.1-8b-instant', smart: 'llama-3.3-70b-versatile' },
-    minimax: { fast: 'MiniMax-M2.7', smart: 'MiniMax-M3' },
-    azure: { fast: 'gpt-4o-mini', smart: 'gpt-4o' }
+const store = createSettingsStore(
+  () => app.getPath('userData'),
+  {
+    // Base URLs are normalized when written (not when read) — same timing as
+    // the original implementation.
+    afterMerge(settings) {
+      settings.baseUrl = normalizeBaseUrl(settings.baseUrl);
+      return settings;
+    },
   }
-};
-
-let data = null;
-
-function deepMerge(base, over) {
-  const out = Array.isArray(base) ? base.slice() : { ...base };
-  for (const k of Object.keys(over || {})) {
-    if (over[k] && typeof over[k] === 'object' && !Array.isArray(over[k]) && typeof base[k] === 'object') {
-      out[k] = deepMerge(base[k], over[k]);
-    } else {
-      if (k === 'aiRules' && typeof over[k] === 'string') {
-        out[k] = over[k].slice(0, MAX_AI_RULES_CHARS);
-      } else {
-        out[k] = over[k];
-      }
-    }
-  }
-  return out;
-}
-
-function load() {
-  if (data) return data;
-  try { data = deepMerge(DEFAULTS, JSON.parse(fs.readFileSync(FILE, 'utf8'))); }
-  catch { data = deepMerge(DEFAULTS, {}); }
-
-
-  return data;
-}
-function save() { try { fs.writeFileSync(FILE, JSON.stringify(data, null, 2)); } catch (e) { /* ignore */ } }
+);
 
 module.exports = {
   MAX_AI_RULES_CHARS,
-  getSettings() { return load(); },
-  setSettings(patch) {
-    load();
-    const nextSettings = deepMerge(data, patch || {});
-    nextSettings.baseUrl = normalizeBaseUrl(nextSettings.baseUrl);
-    data = nextSettings;
-    save();
-    return data;
-  }
+  getSettings() { return store.getSettings(); },
+  setSettings(patch) { return store.setSettings(patch); },
+  /** Null when the last save succeeded; the error otherwise. */
+  lastSaveError() { return store.lastSaveError(); },
 };

--- a/test/gemini-model-config.test.js
+++ b/test/gemini-model-config.test.js
@@ -16,7 +16,9 @@ const DEAD_MODEL_IDS = ['gemini-2.0-flash', 'gemini-1.5-flash', 'gemini-1.5-pro'
 
 const FILES_THAT_CALL_GEMINI = [
   'src/llm.js',
-  'src/store.js',
+  // store.js delegates its defaults to the durable store core, where the
+  // DEFAULTS block (including the Gemini models) now lives.
+  'src/settings-store-core.js',
   'src/stt.js',
   'src/stt-streaming.js'
 ];
@@ -35,10 +37,10 @@ for (const relPath of FILES_THAT_CALL_GEMINI) {
   });
 }
 
-test('store.js default Gemini models match the shared current default', () => {
-  const source = fs.readFileSync(path.join(__dirname, '..', 'src/store.js'), 'utf8');
+test('default Gemini models match the shared current default', () => {
+  const source = fs.readFileSync(path.join(__dirname, '..', 'src/settings-store-core.js'), 'utf8');
   const match = /gemini:\s*\{\s*fast:\s*'([^']+)',\s*smart:\s*'([^']+)'/.exec(source);
-  assert.ok(match, 'could not find the gemini default models block in store.js');
+  assert.ok(match, 'could not find the gemini default models block in settings-store-core.js');
   assert.equal(match[1], CURRENT_GEMINI_DEFAULT);
   assert.equal(match[2], CURRENT_GEMINI_DEFAULT);
 });

--- a/test/store.test.js
+++ b/test/store.test.js
@@ -1,0 +1,118 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+const { createSettingsStore } = require('../src/settings-store-core');
+
+function createTestDirectory(context) {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'cue-store-'));
+  context.after(() => fs.rmSync(directory, { recursive: true, force: true }));
+  return directory;
+}
+
+test('fresh install returns defaults and creates no files until a save', (context) => {
+  const dir = createTestDirectory(context);
+  const store = createSettingsStore(() => dir);
+  assert.equal(store.getSettings().provider, 'openai');
+  assert.equal(fs.readdirSync(dir).length, 0);
+});
+
+test('settings round-trip through disk, including nested merges', (context) => {
+  const dir = createTestDirectory(context);
+  createSettingsStore(() => dir).setSettings({
+    apiKeys: { openai: 'sk-test' },
+    smart: true,
+    localWhisper: { modelId: 'large-v3' },
+  });
+
+  // A brand-new store instance simulates the next app launch.
+  const reloaded = createSettingsStore(() => dir).getSettings();
+  assert.equal(reloaded.apiKeys.openai, 'sk-test');
+  assert.equal(reloaded.smart, true);
+  assert.equal(reloaded.localWhisper.modelId, 'large-v3');
+  // Unrelated defaults survive the merge.
+  assert.equal(reloaded.provider, 'openai');
+  assert.deepEqual(reloaded.models.gemini, { fast: 'gemini-2.5-flash', smart: 'gemini-2.5-flash' });
+});
+
+test('no temp file is left behind after a successful save', (context) => {
+  const dir = createTestDirectory(context);
+  const store = createSettingsStore(() => dir);
+  // The very first save has no previous generation to back up; the .bak
+  // appears once a live file exists to snapshot.
+  store.setSettings({ smart: true });
+  assert.deepEqual(fs.readdirSync(dir), ['cue-data.json']);
+  store.setSettings({ smart: false });
+  assert.deepEqual(fs.readdirSync(dir).sort(), ['cue-data.json', 'cue-data.json.bak']);
+});
+
+// The backup holds the PREVIOUS generation: save A then B leaves A in .bak and
+// B in the live file. Recovery therefore restores A — strictly better than the
+// old behavior of restoring blank defaults for every field.
+test('a corrupt settings file is recovered from the backup generation', (context) => {
+  const dir = createTestDirectory(context);
+  const store = createSettingsStore(() => dir);
+  store.setSettings({ apiKeys: { openai: 'sk-previous' } });
+  store.setSettings({ apiKeys: { anthropic: 'sk-latest' } });
+  assert.equal(store.getSettings().apiKeys.anthropic, 'sk-latest');
+
+  // Simulate the crash mid-write that used to be permanent data loss.
+  fs.writeFileSync(path.join(dir, 'cue-data.json'), '{"apiKeys":{"ope');
+
+  const recovered = createSettingsStore(() => dir).getSettings();
+  assert.equal(recovered.apiKeys.openai, 'sk-previous');
+  assert.equal(recovered.apiKeys.anthropic, '');
+
+  // Recovery heals the live file immediately.
+  const healed = JSON.parse(fs.readFileSync(path.join(dir, 'cue-data.json'), 'utf8'));
+  assert.equal(healed.apiKeys.openai, 'sk-previous');
+});
+
+test('corrupt file with no backup still loads cleanly from defaults', (context) => {
+  const dir = createTestDirectory(context);
+  fs.writeFileSync(path.join(dir, 'cue-data.json'), 'not json at all');
+  const store = createSettingsStore(() => dir);
+  assert.equal(store.getSettings().provider, 'openai');
+  // And saving after that works again.
+  store.setSettings({ apiKeys: { gemini: 'sk-fresh' } });
+  const reloaded = JSON.parse(fs.readFileSync(path.join(dir, 'cue-data.json'), 'utf8'));
+  assert.equal(reloaded.apiKeys.gemini, 'sk-fresh');
+});
+
+test('a failed save is reported via lastSaveError instead of being swallowed', (context) => {
+  const missingDir = path.join(os.tmpdir(), 'cue-store-does-not-exist-' + process.pid);
+  const store = createSettingsStore(() => missingDir);
+  assert.equal(store.lastSaveError(), null);
+
+  // The in-memory settings still update; only the write fails.
+  const result = store.setSettings({ smart: true });
+  assert.equal(result.smart, true);
+  assert.ok(store.lastSaveError());
+  assert.match(String(store.lastSaveError().message), /ENOENT/);
+});
+
+test('the aiRules cap still applies to stored settings', (context) => {
+  const dir = createTestDirectory(context);
+  const store = createSettingsStore(() => dir);
+  const longRules = 'x'.repeat(3000);
+  assert.equal(store.getSettings().aiRules.length, 0);
+  store.setSettings({ aiRules: longRules });
+  assert.equal(store.getSettings().aiRules.length, store.MAX_AI_RULES_CHARS);
+});
+
+test('afterMerge runs on writes only, never on values read from disk', (context) => {
+  const dir = createTestDirectory(context);
+  const trimmer = (s) => ({ ...s, baseUrl: String(s.baseUrl || '').trim() });
+  const store = createSettingsStore(() => dir, { afterMerge: trimmer });
+
+  store.setSettings({ baseUrl: '  http://localhost:11434/v1  ' });
+  assert.equal(store.getSettings().baseUrl, 'http://localhost:11434/v1');
+
+  // A value written to disk verbatim (bypassing setSettings) must load as-is.
+  const raw = JSON.parse(fs.readFileSync(path.join(dir, 'cue-data.json'), 'utf8'));
+  raw.baseUrl = '  http://unnormalized.example  ';
+  fs.writeFileSync(path.join(dir, 'cue-data.json'), JSON.stringify(raw));
+  assert.equal(createSettingsStore(() => dir, { afterMerge: trimmer }).getSettings().baseUrl,
+    '  http://unnormalized.example  ');
+});


### PR DESCRIPTION
The bug:::
src/store.js wrote cue-data.json with a bare fs.writeFileSync, which truncates the destination before writing — a crash or power loss mid-write left corrupt JSON, and load() treated that exactly like a fresh install: every stored API key and interview-prep field silently blanked, unrecoverably (the next save overwrote whatever remained). Save errors were swallowed entirely (catch { /* ignore */ }), so a full disk or read-only profile looked like a successful save. Since cue writes settings on every window move, the file is written constantly in normal use.

The fix:::
- Atomic writes: serialize to .tmp, snapshot the previous good state to .bak, then rename over the live file; rename failures (e.g. antivirus holding the file on Windows) fall back to an in-place write rather than losing the save.
- Corruption recovery: if the live file can't be parsed, the backup generation is loaded instead, the recovery is logged, and the live file is healed immediately.
- Honest errors: save failures are logged via [cue] ... and exposed through a new lastSaveError() accessor. setSettings deliberately remains non-throwing — three existing call sites depend on that contract.

Durability logic lives in a new Electron-free module (settings-store-core.js, factory pattern like WhisperModelManager) because the old store couldn't be required outside Electron at all — which is why it had zero test coverage.

Tests: 8 new cases (node --test): round-trip, fresh install, corrupt-with-backup recovery + heal, corrupt-without-backup, failed-save surfacing, aiRules cap, afterMerge-on-write-only semantics, no temp-file leaks. Full suite: 138 pass